### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.1] - 2025-12-29
 
+### Added
+
+- **Node.js**: Comprehensive test suites with 70%+ code coverage (up from 10%)
+  - `api-coverage.spec.ts` — 91 tests covering all API functions
+  - `edge-cases.spec.ts` — Edge case handling and error conditions
+  - `mark.spec.ts` — Mark class for error location tracking
+  - `options.spec.ts` — Parser and emitter options
+  - `schema.spec.ts` — Schema validation tests
+- **Python**: Stream processing tests (`test_streams.py`)
+- **CI**: npm audit security check for Node.js dependencies
+
 ### Changed
 
 - **Node.js**: Migrated from Prettier to Biome v2.3.10 for formatting and linting
 - **Node.js**: Updated devDependencies with Biome replacing Prettier
 - **Node.js**: Added biome.json configuration with VCS integration and recommended rules
+- **CI**: Updated Node.js versions (20→22 LTS, 22→23 Current)
+- **CI**: Fixed codecov flags for proper coverage reporting
+
+### Fixed
+
+- **Node.js**: Test assertions corrected for YAML 1.2.2 compliance
+- **Node.js**: Memory-intensive tests optimized to prevent OOM in CI
+- **CI**: Python test paths corrected for accurate coverage reporting
 
 ### Internal
 
 - Removed unused root pyproject.toml and uv.lock files (Python tooling is in python/ directory)
 - CI lint step now enforces quality (removed continue-on-error)
+- Vitest configured with sequential execution to prevent memory pressure
 
 ## [0.3.0] - 2025-12-29
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -28,10 +28,10 @@ repository = "https://github.com/bug-ops/fast-yaml"
 
 [workspace.dependencies]
 # Internal crates
-fast-yaml-core = { path = "crates/fast-yaml-core", version = "0.3.0" }
-fast-yaml-ffi = { path = "crates/fast-yaml-ffi", version = "0.3.0" }
-fast-yaml-linter = { path = "crates/fast-yaml-linter", version = "0.3.0" }
-fast-yaml-parallel = { path = "crates/fast-yaml-parallel", version = "0.3.0" }
+fast-yaml-core = { path = "crates/fast-yaml-core", version = "0.3.1" }
+fast-yaml-ffi = { path = "crates/fast-yaml-ffi", version = "0.3.1" }
+fast-yaml-linter = { path = "crates/fast-yaml-linter", version = "0.3.1" }
+fast-yaml-parallel = { path = "crates/fast-yaml-parallel", version = "0.3.1" }
 
 # External dependencies
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ import fast_yaml
 # Parse YAML
 data = fast_yaml.safe_load("""
 name: fast-yaml
-version: 0.3.0
+version: 0.3.1
 features:
   - fast
   - safe
@@ -134,7 +134,7 @@ features:
 """)
 
 print(data)
-# {'name': 'fast-yaml', 'version': '0.1.0', 'features': ['fast', 'safe', 'yaml-1.2.2']}
+# {'name': 'fast-yaml', 'version': '0.3.1', 'features': ['fast', 'safe', 'yaml-1.2.2']}
 
 # Serialize to YAML
 yaml_str = fast_yaml.safe_dump(data)
@@ -152,7 +152,7 @@ import { safeLoad, safeDump } from 'fastyaml-rs';
 // Parse YAML
 const data = safeLoad(`
 name: fast-yaml
-version: 0.3.0
+version: 0.3.1
 features:
   - fast
   - safe
@@ -160,7 +160,7 @@ features:
 `);
 
 console.log(data);
-// { name: 'fast-yaml', version: '0.1.0', features: ['fast', 'safe', 'yaml-1.2.2'] }
+// { name: 'fast-yaml', version: '0.3.1', features: ['fast', 'safe', 'yaml-1.2.2'] }
 
 // Serialize to YAML
 const yamlStr = safeDump(data);
@@ -431,7 +431,7 @@ fast-yaml/
 - **Python**: 3.9+
 - **Node.js**: 20+
 - **Crates**: 6 (core, linter, parallel, ffi, python, nodejs)
-- **Tests**: 234+ (Rust) + Python + Node.js test suites
+- **Tests**: 234+ (Rust) + 94%+ Python coverage + 70%+ Node.js coverage
 
 ## Contributing
 

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -33,7 +33,7 @@ import { safeLoad, safeDump } from 'fastyaml-rs';
 // Parse YAML
 const data = safeLoad(`
 name: fast-yaml
-version: 0.3.0
+version: 0.3.1
 features:
   - fast
   - safe
@@ -41,7 +41,7 @@ features:
 `);
 
 console.log(data);
-// { name: 'fast-yaml', version: '0.1.0', features: ['fast', 'safe', 'yaml-1.2.2'] }
+// { name: 'fast-yaml', version: '0.3.1', features: ['fast', 'safe', 'yaml-1.2.2'] }
 
 // Serialize to YAML
 const yamlStr = safeDump(data);

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fastyaml-rs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fastyaml-rs",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@biomejs/biome": "^2.3.10",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastyaml-rs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Fast YAML 1.2.2 parser, linter, and parallel processor for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastyaml-rs"
-version = "0.3.0"
+version = "0.3.1"
 description = "A fast YAML parser and linter for Python, powered by Rust"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Release v0.3.1 with version bumps and documentation updates.

### Changes

- Bump version to 0.3.1 in all manifests:
  - `Cargo.toml` (workspace)
  - `nodejs/package.json`
  - `python/pyproject.toml`
- Update README examples to reference version 0.3.1
- Update CHANGELOG with 0.3.1 release notes

### Release Highlights (from CHANGELOG)

**Added:**
- Node.js: Comprehensive test suites with 70%+ code coverage (up from 10%)
- Python: Stream processing tests
- CI: npm audit security check

**Changed:**
- Node.js: Migrated from Prettier to Biome
- CI: Updated Node.js versions (20→22 LTS, 22→23 Current)
- CI: Fixed codecov flags

**Fixed:**
- Node.js: Test assertions corrected for YAML 1.2.2 compliance
- Node.js: Memory-intensive tests optimized
- CI: Python test paths corrected