### PR TITLE
fix(linter): enable duplicate key detection by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `DuplicateKeysRule` now fires by default: `LintConfig::default()` sets `allow_duplicate_keys: false`
+- Fixed false positives in duplicate key detection — nested keys with same name no longer reported as duplicates
+
+### Added
+
+- `--allow-duplicate-keys` CLI flag for `fy lint` to opt-in to allowing duplicate keys
+- `LintConfig::with_allow_duplicate_keys` builder method
+
 ## [0.5.2] - 2026-03-17
 
 ### Changed

--- a/crates/fast-yaml-cli/src/cli.rs
+++ b/crates/fast-yaml-cli/src/cli.rs
@@ -123,6 +123,10 @@ pub enum Command {
         /// Lint output format
         #[arg(long, value_enum, default_value = "text")]
         format: LintFormat,
+
+        /// Allow duplicate keys (opt-in, suppresses duplicate key errors)
+        #[arg(long)]
+        allow_duplicate_keys: bool,
     },
 }
 

--- a/crates/fast-yaml-cli/src/commands/lint.rs
+++ b/crates/fast-yaml-cli/src/commands/lint.rs
@@ -11,14 +11,21 @@ pub struct LintCommand {
     config: CommonConfig,
     max_line_length: usize,
     format: LintFormat,
+    allow_duplicate_keys: bool,
 }
 
 impl LintCommand {
-    pub const fn new(config: CommonConfig, max_line_length: usize, format: LintFormat) -> Self {
+    pub const fn new(
+        config: CommonConfig,
+        max_line_length: usize,
+        format: LintFormat,
+        allow_duplicate_keys: bool,
+    ) -> Self {
         Self {
             config,
             max_line_length,
             format,
+            allow_duplicate_keys,
         }
     }
 
@@ -33,7 +40,8 @@ impl LintCommand {
         // Configure linter using formatter indent from config
         let lint_config = LintConfig::new()
             .with_max_line_length(Some(self.max_line_length))
-            .with_indent_size(self.config.formatter.indent() as usize);
+            .with_indent_size(self.config.formatter.indent() as usize)
+            .with_allow_duplicate_keys(self.allow_duplicate_keys);
 
         // Create linter with all rules
         let mut linter = Linter::with_config(lint_config);
@@ -124,7 +132,7 @@ mod tests {
         };
 
         let config = create_test_config(true, false, false, 2);
-        let cmd = LintCommand::new(config, 120, LintFormat::Text);
+        let cmd = LintCommand::new(config, 120, LintFormat::Text, false);
         let result = cmd.execute(&input);
 
         assert!(result.is_ok());
@@ -139,7 +147,7 @@ mod tests {
         };
 
         let config = create_test_config(true, false, false, 2);
-        let cmd = LintCommand::new(config, 80, LintFormat::Text);
+        let cmd = LintCommand::new(config, 80, LintFormat::Text, false);
         let result = cmd.execute(&input);
 
         // Should succeed (warnings don't cause failure)
@@ -155,7 +163,7 @@ mod tests {
         };
 
         let config = create_test_config(true, false, false, 2);
-        let cmd = LintCommand::new(config, 120, LintFormat::Text);
+        let cmd = LintCommand::new(config, 120, LintFormat::Text, false);
         let result = cmd.execute(&input);
 
         // Should fail with parse error
@@ -170,7 +178,7 @@ mod tests {
         };
 
         let config = create_test_config(true, false, false, 2);
-        let cmd = LintCommand::new(config, 120, LintFormat::Text);
+        let cmd = LintCommand::new(config, 120, LintFormat::Text, false);
         let result = cmd.execute(&input);
 
         assert!(result.is_ok());
@@ -185,7 +193,37 @@ mod tests {
         };
 
         let config = create_test_config(false, false, false, 2);
-        let cmd = LintCommand::new(config, 120, LintFormat::Json);
+        let cmd = LintCommand::new(config, 120, LintFormat::Json, false);
+        let result = cmd.execute(&input);
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), ExitCode::Success);
+    }
+
+    #[test]
+    fn test_lint_duplicate_keys_reported_by_default() {
+        let input = InputSource {
+            content: "key: value1\nkey: value2\nother: data".to_string(),
+            origin: InputOrigin::Stdin,
+        };
+
+        let config = create_test_config(false, false, false, 2);
+        let cmd = LintCommand::new(config, 120, LintFormat::Text, false);
+        let result = cmd.execute(&input);
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), ExitCode::LintErrors);
+    }
+
+    #[test]
+    fn test_lint_duplicate_keys_allowed_when_flag_set() {
+        let input = InputSource {
+            content: "key: value1\nkey: value2\nother: data".to_string(),
+            origin: InputOrigin::Stdin,
+        };
+
+        let config = create_test_config(false, false, false, 2);
+        let cmd = LintCommand::new(config, 120, LintFormat::Text, true);
         let result = cmd.execute(&input);
 
         assert!(result.is_ok());

--- a/crates/fast-yaml-cli/src/main.rs
+++ b/crates/fast-yaml-cli/src/main.rs
@@ -176,12 +176,18 @@ fn run() -> Result<ExitCode> {
             max_line_length,
             indent_size,
             format,
+            allow_duplicate_keys,
         }) => {
             let input = InputSource::from_args(file)?;
             let lint_config = common_config
                 .clone()
                 .with_formatter(config::FormatterConfig::new().with_indent(indent_size as u8));
-            let cmd = commands::lint::LintCommand::new(lint_config, max_line_length, format);
+            let cmd = commands::lint::LintCommand::new(
+                lint_config,
+                max_line_length,
+                format,
+                allow_duplicate_keys,
+            );
             cmd.execute(&input)?
         }
         None => {

--- a/crates/fast-yaml-cli/tests/cli_tests.rs
+++ b/crates/fast-yaml-cli/tests/cli_tests.rs
@@ -172,17 +172,28 @@ fn test_lint_json_format() {
 
 #[test]
 #[cfg(feature = "linter")]
-fn test_lint_duplicate_keys_disabled_by_default() {
-    // Duplicate key detection is disabled by default to avoid false positives
-    // from nested keys with the same name in different contexts
+fn test_lint_duplicate_keys_reported_by_default() {
     Command::cargo_bin("fy")
         .unwrap()
         .arg("lint")
         .write_stdin("key: value1\nkey: value2\n")
         .assert()
+        .failure()
+        .code(2)
+        .stdout(predicate::str::contains("duplicate key 'key'"));
+}
+
+#[test]
+#[cfg(feature = "linter")]
+fn test_lint_duplicate_keys_allowed_with_flag() {
+    Command::cargo_bin("fy")
+        .unwrap()
+        .arg("lint")
+        .arg("--allow-duplicate-keys")
+        .write_stdin("key: value1\nkey: value2\n")
+        .assert()
         .success()
-        .code(0)
-        .stdout(predicate::str::contains("0 errors, 0 warnings"));
+        .code(0);
 }
 
 #[test]

--- a/crates/fast-yaml-linter/src/linter.rs
+++ b/crates/fast-yaml-linter/src/linter.rs
@@ -43,9 +43,7 @@ impl Default for LintConfig {
             indent_size: 2,
             require_document_start: false,
             require_document_end: false,
-            // Duplicate key detection disabled by default due to false positives
-            // from nested keys with same names (e.g., top-level "name" and nested "author.name")
-            allow_duplicate_keys: true,
+            allow_duplicate_keys: false,
             disabled_rules: HashSet::new(),
             rule_configs: HashMap::new(),
         }
@@ -198,6 +196,22 @@ impl LintConfig {
         self.get_rule_config(rule_code)
             .and_then(|rc| rc.severity)
             .unwrap_or(default)
+    }
+
+    /// Allows or disallows duplicate keys.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fast_yaml_linter::LintConfig;
+    ///
+    /// let config = LintConfig::new().with_allow_duplicate_keys(true);
+    /// assert!(config.allow_duplicate_keys);
+    /// ```
+    #[must_use]
+    pub const fn with_allow_duplicate_keys(mut self, allow: bool) -> Self {
+        self.allow_duplicate_keys = allow;
+        self
     }
 
     /// Adds a rule-specific configuration.
@@ -427,8 +441,7 @@ mod tests {
         assert_eq!(config.max_line_length, Some(80));
         assert_eq!(config.indent_size, 2);
         assert!(!config.require_document_start);
-        // Duplicate key detection is disabled by default
-        assert!(config.allow_duplicate_keys);
+        assert!(!config.allow_duplicate_keys);
     }
 
     #[test]

--- a/crates/fast-yaml-linter/src/rules/duplicate_keys.rs
+++ b/crates/fast-yaml-linter/src/rules/duplicate_keys.rs
@@ -65,9 +65,14 @@ fn check_top_level(
             .filter_map(|(k, _)| k.as_str().map(String::from))
             .collect();
 
-        // For each unique key, find ALL occurrences in source and detect duplicates
+        // For each unique key, find ALL occurrences in source and detect duplicates.
+        // Filter to column 1 (zero indentation) to avoid false positives from nested keys.
         for key_str in &unique_keys {
-            let all_spans = mapper.find_all_key_spans(key_str);
+            let all_spans: Vec<_> = mapper
+                .find_all_key_spans(key_str)
+                .into_iter()
+                .filter(|s| s.start.column == 1)
+                .collect();
 
             // If we find more than one occurrence, all after the first are duplicates
             if all_spans.len() > 1 {


### PR DESCRIPTION
## Summary

- `LintConfig::default()` now sets `allow_duplicate_keys = false`, enabling `DuplicateKeysRule` by default
- Fixed false positives: detection now restricted to top-level keys only (column 1), preventing nested keys with the same name from being flagged
- Added `--allow-duplicate-keys` CLI flag to `fy lint` for opt-in suppression
- Added `LintConfig::with_allow_duplicate_keys` builder method

## Test plan

- [ ] `fy lint /tmp/dup.yaml` with duplicate keys returns exit code 2 and reports error
- [ ] `fy lint --allow-duplicate-keys /tmp/dup.yaml` returns exit code 0
- [ ] Nested keys with same names in different contexts produce no false positives
- [ ] All 869 tests pass

Closes #60