### PR TITLE
fix(core): stop quoting YAML 1.1 bool-like keys in formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `DuplicateKeysRule` now fires by default: `LintConfig::default()` sets `allow_duplicate_keys: false`
 - Fixed false positives in duplicate key detection — nested keys with same name no longer reported as duplicates
+- **Core/CLI**: `fy format` no longer quotes YAML 1.1 boolean-like keys (`on`, `off`, `yes`, `no`).
+  In YAML 1.2.2 Core Schema these are plain strings; only `true`, `false`, `null`, and `~` have
+  special meaning. The formatter now always uses the streaming path which preserves the original
+  scalar style from the parser, instead of the DOM path (saphyr `YamlEmitter`) that incorrectly
+  added quotes for YAML 1.1 compatibility. This fixes broken GitHub Actions workflow files after
+  `fy format -i`. (#64)
 
 ### Added
 
 - `--allow-duplicate-keys` CLI flag for `fy lint` to opt-in to allowing duplicate keys
 - `LintConfig::with_allow_duplicate_keys` builder method
+
+### Changed
+
+- **Core**: `Emitter::format_with_config` now always uses the streaming formatter when the
+  `streaming` feature is enabled, regardless of input size. The trailing newline is now always
+  emitted for all file sizes (consistent POSIX text-file behavior).
 
 ## [0.5.2] - 2026-03-17
 

--- a/crates/fast-yaml-cli/tests/backward_compat.rs
+++ b/crates/fast-yaml-cli/tests/backward_compat.rs
@@ -17,7 +17,7 @@ fn fy() -> Command {
 #[test]
 fn test_stdin_mode_unchanged() {
     let input = "key:  value\n";
-    let expected = "key: value";
+    let expected = "key: value\n";
 
     fy().arg("format")
         .write_stdin(input)
@@ -52,7 +52,7 @@ fn test_single_file_stdout_unchanged() {
     let temp = TempDir::new().unwrap();
     let file = temp.path().join("test.yaml");
     let input = "key:  value\n";
-    let expected = "key: value";
+    let expected = "key: value\n";
 
     fs::write(&file, input).unwrap();
 
@@ -70,7 +70,7 @@ fn test_single_file_in_place_unchanged() {
     let temp = TempDir::new().unwrap();
     let file = temp.path().join("test.yaml");
     let input = "key:  value\n";
-    let expected = "key: value";
+    let expected = "key: value\n";
 
     fs::write(&file, input).unwrap();
 
@@ -140,7 +140,7 @@ fn test_format_nonexistent_file_error() {
 #[test]
 fn test_default_command_stdin() {
     let input = "key:  value\n";
-    let expected = "key: value";
+    let expected = "key: value\n";
 
     fy().write_stdin(input).assert().success().stdout(expected);
 }
@@ -173,7 +173,7 @@ fn test_single_file_with_output_flag() {
     let input_file = temp.path().join("input.yaml");
     let output_file = temp.path().join("output.yaml");
     let input = "key:  value\n";
-    let expected = "key: value";
+    let expected = "key: value\n";
 
     fs::write(&input_file, input).unwrap();
 

--- a/crates/fast-yaml-cli/tests/batch_format.rs
+++ b/crates/fast-yaml-cli/tests/batch_format.rs
@@ -36,8 +36,8 @@ fn test_batch_multiple_files() {
     .assert()
     .success();
 
-    assert_eq!(fs::read_to_string(&file1).unwrap(), "key1: value1");
-    assert_eq!(fs::read_to_string(&file2).unwrap(), "key2: value2");
+    assert_eq!(fs::read_to_string(&file1).unwrap(), "key1: value1\n");
+    assert_eq!(fs::read_to_string(&file2).unwrap(), "key2: value2\n");
 }
 
 #[test]
@@ -57,8 +57,8 @@ fn test_batch_directory_recursive() {
         .assert()
         .success();
 
-    assert_eq!(fs::read_to_string(&file1).unwrap(), "key1: value1");
-    assert_eq!(fs::read_to_string(&file2).unwrap(), "key2: value2");
+    assert_eq!(fs::read_to_string(&file1).unwrap(), "key1: value1\n");
+    assert_eq!(fs::read_to_string(&file2).unwrap(), "key2: value2\n");
 }
 
 #[test]
@@ -79,7 +79,7 @@ fn test_batch_directory_no_recursive() {
         .success();
 
     // Top-level file should be formatted
-    assert_eq!(fs::read_to_string(&file1).unwrap(), "key1: value1");
+    assert_eq!(fs::read_to_string(&file1).unwrap(), "key1: value1\n");
 
     // Subdirectory file should NOT be formatted
     assert_eq!(fs::read_to_string(&file2).unwrap(), "key2:  value2\n");
@@ -109,7 +109,7 @@ fn test_batch_exclude_pattern() {
     .success();
 
     // Main file should be formatted
-    assert_eq!(fs::read_to_string(&file1).unwrap(), "key1: value1");
+    assert_eq!(fs::read_to_string(&file1).unwrap(), "key1: value1\n");
 
     // Vendor file should NOT be formatted
     assert_eq!(fs::read_to_string(&file2).unwrap(), "key2:  value2\n");
@@ -138,7 +138,7 @@ fn test_batch_include_pattern() {
     assert_eq!(fs::read_to_string(&yaml_file).unwrap(), "key1:  value1\n");
 
     // .yml file should be formatted
-    assert_eq!(fs::read_to_string(&yml_file).unwrap(), "key2: value2");
+    assert_eq!(fs::read_to_string(&yml_file).unwrap(), "key2: value2\n");
 
     // .txt file should NOT be touched
     assert_eq!(fs::read_to_string(&txt_file).unwrap(), "key3:  value3\n");
@@ -176,8 +176,8 @@ fn test_batch_stdin_files() {
         .assert()
         .success();
 
-    assert_eq!(fs::read_to_string(&file1).unwrap(), "key1: value1");
-    assert_eq!(fs::read_to_string(&file2).unwrap(), "key2: value2");
+    assert_eq!(fs::read_to_string(&file1).unwrap(), "key1: value1\n");
+    assert_eq!(fs::read_to_string(&file2).unwrap(), "key2: value2\n");
 }
 
 #[test]
@@ -210,7 +210,7 @@ fn test_batch_mixed_success_failure() {
         .code(1);
 
     // Valid file should still be formatted
-    assert_eq!(fs::read_to_string(&valid).unwrap(), "key: value");
+    assert_eq!(fs::read_to_string(&valid).unwrap(), "key: value\n");
 }
 
 #[test]
@@ -233,7 +233,7 @@ fn test_batch_jobs_parallel() {
         let file = dir.join(format!("file{i}.yaml"));
         assert_eq!(
             fs::read_to_string(&file).unwrap(),
-            format!("key{i}: value{i}")
+            format!("key{i}: value{i}\n")
         );
     }
 }
@@ -306,7 +306,7 @@ fn test_batch_respects_gitignore() {
         .success();
 
     // Tracked file should be formatted
-    assert_eq!(fs::read_to_string(&tracked).unwrap(), "key1: value1");
+    assert_eq!(fs::read_to_string(&tracked).unwrap(), "key1: value1\n");
 
     // Ignored file should NOT be formatted (respects .gitignore)
     assert_eq!(fs::read_to_string(&ignored).unwrap(), "key2:  value2\n");

--- a/crates/fast-yaml-core/src/emitter.rs
+++ b/crates/fast-yaml-core/src/emitter.rs
@@ -425,26 +425,28 @@ impl Emitter {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn format_with_config(input: &str, config: &EmitterConfig) -> EmitResult<String> {
+        // Always prefer the streaming formatter when available.
+        //
+        // The DOM-based path (saphyr's YamlEmitter) quotes YAML 1.1 boolean-like
+        // keys (`on`, `off`, `yes`, `no`) even though they are plain strings in
+        // YAML 1.2.2 Core Schema. The streaming formatter preserves the original
+        // ScalarStyle from the parser, so it never introduces spurious quoting.
         #[cfg(feature = "streaming")]
-        {
-            if crate::streaming::is_streaming_suitable(input) {
-                // Prefer arena allocation when available
-                #[cfg(feature = "arena")]
-                {
-                    return crate::streaming::format_streaming_arena(input, config);
-                }
-                #[cfg(not(feature = "arena"))]
-                {
-                    return crate::streaming::format_streaming(input, config);
-                }
-            }
-        }
+        // Prefer arena allocation when available
+        #[cfg(feature = "arena")]
+        return crate::streaming::format_streaming_arena(input, config);
 
-        // Fall back to DOM-based formatting
-        let value = crate::Parser::parse_str(input)
-            .map_err(|e| EmitError::Emit(e.to_string()))?
-            .ok_or_else(|| EmitError::Emit("Empty document".to_string()))?;
-        Self::emit_str_with_config(&value, config)
+        #[cfg(all(feature = "streaming", not(feature = "arena")))]
+        return crate::streaming::format_streaming(input, config);
+
+        // Fall back to DOM-based formatting (no streaming feature)
+        #[cfg(not(feature = "streaming"))]
+        {
+            let value = crate::Parser::parse_str(input)
+                .map_err(|e| EmitError::Emit(e.to_string()))?
+                .ok_or_else(|| EmitError::Emit("Empty document".to_string()))?;
+            Self::emit_str_with_config(&value, config)
+        }
     }
 
     /// Format a YAML string with default configuration.
@@ -914,5 +916,74 @@ mod tests {
         let input = "key: value\nlist:\n  - item1\n  - item2\nnumber: 42\n";
         let result = Emitter::fix_special_floats(input);
         assert_eq!(result, input, "No changes should be made for normal YAML");
+    }
+
+    // Regression tests for issue #64: YAML 1.1 boolean-like keys must not be quoted.
+    // In YAML 1.2.2 Core Schema, `on`, `off`, `yes`, `no` are plain strings.
+    #[cfg(feature = "streaming")]
+    #[test]
+    fn test_format_yaml11_bool_key_on() {
+        let result = Emitter::format("on: push").unwrap();
+        assert!(
+            !result.contains("\"on\""),
+            "key `on` must not be quoted, got: {result}"
+        );
+        assert!(result.contains("on:"), "key `on` must appear unquoted");
+    }
+
+    #[cfg(feature = "streaming")]
+    #[test]
+    fn test_format_yaml11_bool_key_off() {
+        let result = Emitter::format("off: value").unwrap();
+        assert!(
+            !result.contains("\"off\""),
+            "key `off` must not be quoted, got: {result}"
+        );
+        assert!(result.contains("off:"), "key `off` must appear unquoted");
+    }
+
+    #[cfg(feature = "streaming")]
+    #[test]
+    fn test_format_yaml11_bool_key_yes() {
+        let result = Emitter::format("yes: value").unwrap();
+        assert!(
+            !result.contains("\"yes\""),
+            "key `yes` must not be quoted, got: {result}"
+        );
+        assert!(result.contains("yes:"), "key `yes` must appear unquoted");
+    }
+
+    #[cfg(feature = "streaming")]
+    #[test]
+    fn test_format_yaml11_bool_key_no() {
+        let result = Emitter::format("no: value").unwrap();
+        assert!(
+            !result.contains("\"no\""),
+            "key `no` must not be quoted, got: {result}"
+        );
+        assert!(result.contains("no:"), "key `no` must appear unquoted");
+    }
+
+    #[cfg(feature = "streaming")]
+    #[test]
+    fn test_format_github_actions_workflow() {
+        let yaml = "on:\n  push:\n    branches:\n      - main\n";
+        let result = Emitter::format(yaml).unwrap();
+        assert!(
+            !result.contains("\"on\""),
+            "GitHub Actions `on:` trigger must not be quoted, got: {result}"
+        );
+        assert!(result.contains("on:"), "on: key must appear unquoted");
+        assert!(result.contains("push:"), "push: key must appear");
+    }
+
+    #[cfg(feature = "streaming")]
+    #[test]
+    fn test_format_yaml12_bools_unaffected() {
+        // YAML 1.2.2 actual booleans must still be emitted as true/false
+        let yaml = "enabled: true\ndisabled: false\n";
+        let result = Emitter::format(yaml).unwrap();
+        assert!(result.contains("true"), "true value must be preserved");
+        assert!(result.contains("false"), "false value must be preserved");
     }
 }


### PR DESCRIPTION
## Summary

- `fy format` was wrapping `on`, `off`, `yes`, `no` mapping keys in double quotes, treating them as YAML 1.1 boolean-like values
- This broke GitHub Actions workflow files where `on:` identifies workflow triggers
- Root cause: `format_with_config` fell back to the DOM path (saphyr `YamlEmitter`) for small files (<1KB); saphyr's emitter adds defensive quoting for YAML 1.1 compat
- Fix: `format_with_config` now always uses the streaming formatter when the `streaming` feature is enabled; the streaming path preserves the original `ScalarStyle` from the parser, so it never introduces spurious quotes
- Side effect: formatter now consistently emits a trailing newline for all input sizes (POSIX text-file convention); test expectations updated accordingly

## Test plan

- [ ] `echo "on: push" | fy format` outputs `on: push` (no quotes)
- [ ] All four affected keys (`on`, `off`, `yes`, `no`) covered by new regression tests in `emitter.rs`
- [ ] GitHub Actions workflow example test: `on:\n  push:\n    branches:\n      - main`
- [ ] `true`/`false` YAML 1.2.2 booleans unaffected
- [ ] All 872 existing tests pass
- [ ] Pre-commit checks: fmt, clippy, nextest, deny, doc — all clean

Closes #64