### PR TITLE
fix(core): preserve float types in fy format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `fy format` no longer changes float type to integer: `1.0` stays `1.0` (not `1`), `1.23e10` stays `1.23e10` (not `12300000000`). Root cause: streaming formatter now handles all input sizes, preserving the original scalar text representation from the parser. Previously, inputs smaller than 1 KB fell back to DOM-based formatting which lost float precision through Rust's float Display trait.
+- `fy format` output now consistently ends with a trailing newline (POSIX convention).
 - `DuplicateKeysRule` now fires by default: `LintConfig::default()` sets `allow_duplicate_keys: false`
 - Fixed false positives in duplicate key detection — nested keys with same name no longer reported as duplicates
 - **Core/CLI**: `fy format` no longer quotes YAML 1.1 boolean-like keys (`on`, `off`, `yes`, `no`).

--- a/crates/fast-yaml-core/src/emitter.rs
+++ b/crates/fast-yaml-core/src/emitter.rs
@@ -986,4 +986,39 @@ mod tests {
         assert!(result.contains("true"), "true value must be preserved");
         assert!(result.contains("false"), "false value must be preserved");
     }
+
+    #[test]
+    #[cfg(feature = "streaming")]
+    fn test_format_preserves_float_types() {
+        // Regression tests for issue #66: fy format must not change float type to integer
+
+        // 1.0 must remain 1.0
+        let result = Emitter::format("version: 1.0").unwrap();
+        assert!(
+            result.contains("1.0"),
+            "version: 1.0 must emit as float, got: {result}"
+        );
+        assert!(
+            !result.contains(": 1\n"),
+            "version: 1.0 must not become integer 1, got: {result}"
+        );
+
+        // Scientific notation must be preserved
+        let result = Emitter::format("count: 1.23e10").unwrap();
+        assert!(
+            result.contains("1.23e10") || result.contains("1.23e+10"),
+            "Scientific notation must be preserved, got: {result}"
+        );
+        assert!(
+            !result.contains("12300000000"),
+            "Scientific notation must not expand to integer, got: {result}"
+        );
+
+        // Regular float preserved
+        let result = Emitter::format("pi: 3.14").unwrap();
+        assert!(
+            result.contains("3.14"),
+            "3.14 must be preserved, got: {result}"
+        );
+    }
 }

--- a/crates/fast-yaml-core/src/streaming/mod.rs
+++ b/crates/fast-yaml-core/src/streaming/mod.rs
@@ -99,28 +99,31 @@ fn fix_special_float_value(value: &str) -> &str {
 /// # {
 /// use fast_yaml_core::streaming::is_streaming_suitable;
 ///
-/// // Small files - use DOM
-/// assert!(!is_streaming_suitable("small: yaml"));
+/// // Regular files - use streaming (preserves float types)
+/// assert!(is_streaming_suitable("version: 1.0"));
+/// assert!(is_streaming_suitable("small: yaml"));
 ///
-/// // Large files - use streaming
+/// // Large files - also use streaming
 /// let large = "key: value\n".repeat(1000);
 /// assert!(is_streaming_suitable(&large));
 /// # }
 /// ```
 pub fn is_streaming_suitable(input: &str) -> bool {
-    // Small files are fast enough with DOM-based formatting
-    if input.len() < 1024 {
-        return false;
-    }
+    // Streaming preserves the original scalar text (e.g. "1.0" stays "1.0"),
+    // while DOM-based formatting loses type information (float 1.0 → integer 1).
+    // Always prefer streaming to maintain YAML 1.2.2 Core Schema type fidelity.
 
-    // Count indicators of complexity that benefit from DOM
-    let anchor_count = input.bytes().filter(|&b| b == b'&').count();
-    let alias_count = input.bytes().filter(|&b| b == b'*').count();
+    // Heavy anchor/alias usage: avoid streaming only when anchor density is very
+    // high, because the DOM path resolves aliases during parse.
+    let len = input.len();
+    if len > 0 {
+        let anchor_count = input.bytes().filter(|&b| b == b'&').count();
+        let alias_count = input.bytes().filter(|&b| b == b'*').count();
 
-    // Heavy anchor/alias usage benefits from DOM for resolution
-    // Threshold: more than 1 anchor/alias per 1000 bytes
-    if anchor_count + alias_count > input.len() / 1000 {
-        return false;
+        // More than 10 anchors/aliases per 1000 bytes → fall back to DOM
+        if (anchor_count + alias_count) * 100 > len {
+            return false;
+        }
     }
 
     true
@@ -225,8 +228,11 @@ double: "quoted""#;
 
     #[test]
     fn test_is_streaming_suitable_small() {
-        assert!(!is_streaming_suitable("small: yaml"));
-        assert!(!is_streaming_suitable("key: value\nlist:\n  - a\n  - b"));
+        // Small files now use streaming to preserve float types (issue #66)
+        assert!(is_streaming_suitable("small: yaml"));
+        assert!(is_streaming_suitable("key: value\nlist:\n  - a\n  - b"));
+        assert!(is_streaming_suitable("version: 1.0"));
+        assert!(is_streaming_suitable("count: 1.23e10"));
     }
 
     #[test]
@@ -245,6 +251,41 @@ double: "quoted""#;
         assert!(
             !is_streaming_suitable(&heavy_anchors),
             "Heavy anchor usage should not be suitable for streaming"
+        );
+    }
+
+    #[test]
+    fn test_format_streaming_float_type_preservation() {
+        // Regression tests for issue #66: float values must not be converted to integers
+        let config = EmitterConfig::default();
+
+        // 1.0 must remain 1.0, not become 1
+        let result = format_streaming("version: 1.0", &config).unwrap();
+        assert!(
+            result.contains("1.0"),
+            "1.0 must stay as float, got: {result}"
+        );
+        assert!(
+            !result.contains(": 1\n"),
+            "1.0 must not be emitted as integer 1, got: {result}"
+        );
+
+        // Scientific notation must be preserved, not expanded to integer
+        let result = format_streaming("count: 1.23e10", &config).unwrap();
+        assert!(
+            result.contains("1.23e10") || result.contains("1.23e+10"),
+            "Scientific notation must be preserved, got: {result}"
+        );
+        assert!(
+            !result.contains("12300000000"),
+            "Scientific notation must not expand to integer, got: {result}"
+        );
+
+        // Regular float (3.14) must be preserved as-is
+        let result = format_streaming("pi: 3.14", &config).unwrap();
+        assert!(
+            result.contains("3.14"),
+            "3.14 must be preserved, got: {result}"
         );
     }
 


### PR DESCRIPTION
## Summary

- `fy format` no longer changes float type to integer: `1.0` stays `1.0`, `1.23e10` stays `1.23e10`
- Root cause: inputs < 1 KB fell back to DOM-based formatting which loses float precision via Rust's `Display` trait (`1.0` → `"1"`)
- Fix: streaming formatter now handles all input sizes, preserving original scalar text from saphyr_parser events
- Side effect: output now consistently ends with a trailing newline (POSIX convention); updated affected tests

## Test plan

- [x] Regression tests added in `fast-yaml-core` for all three reproduction cases from the issue
- [x] All 871 tests pass
- [x] `cargo +nightly fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo deny check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc` clean

Closes #66