### PR TITLE
fix(cli): error on fy format <dir> without -i; fix --dry-run label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scalar style from the parser, instead of the DOM path (saphyr `YamlEmitter`) that incorrectly
   added quotes for YAML 1.1 compatibility. This fixes broken GitHub Actions workflow files after
   `fy format -i`. (#64)
+- `fy format <directory>` without `-i` now returns an error instead of silently validating files (#69)
+- `fy format --dry-run` now reports "would change: N" instead of "skipped: N" (#69)
 
 ### Added
 

--- a/crates/fast-yaml-cli/src/commands/format_batch.rs
+++ b/crates/fast-yaml-cli/src/commands/format_batch.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use fast_yaml_core::emitter::EmitterConfig;
 use fast_yaml_parallel::{BatchResult as ParallelBatchResult, FileProcessor};
 
@@ -104,21 +104,19 @@ pub fn execute_batch(
         // In-place: format and write
         processor.format_in_place(&file_paths, &emitter_config)
     } else {
-        // Default: just parse/validate
-        processor.parse_files(&file_paths)
+        bail!("use -i to format files in-place or --dry-run to preview changes");
     };
 
     // Report results using BatchSummary event
-    // Note: fast-yaml-parallel uses 'changed' instead of 'formatted'
-    // and doesn't have 'skipped' (dry_run is CLI-specific)
-    let skipped = if config.dry_run { result.changed } else { 0 };
+    // In dry-run mode, 'changed' means "would change"; in in-place mode it means "formatted".
+    let would_change = if config.dry_run { result.changed } else { 0 };
     let formatted = if config.dry_run { 0 } else { result.changed };
 
     reporter.report(ReportEvent::BatchSummary {
         total: result.total,
         formatted,
         unchanged: result.success - result.changed,
-        skipped,
+        would_change,
         failed: result.failed,
         duration: result.duration,
     })?;

--- a/crates/fast-yaml-cli/src/reporter/events.rs
+++ b/crates/fast-yaml-cli/src/reporter/events.rs
@@ -61,8 +61,8 @@ pub enum ReportEvent<'a> {
         formatted: usize,
         /// Files that were unchanged
         unchanged: usize,
-        /// Files that were skipped
-        skipped: usize,
+        /// Files that would change (dry-run mode)
+        would_change: usize,
         /// Files that failed
         failed: usize,
         /// Total duration
@@ -159,7 +159,7 @@ mod tests {
                 total: 10,
                 formatted: 5,
                 unchanged: 3,
-                skipped: 1,
+                would_change: 1,
                 failed: 1,
                 duration: Duration::from_secs(5),
             },

--- a/crates/fast-yaml-cli/src/reporter/output.rs
+++ b/crates/fast-yaml-cli/src/reporter/output.rs
@@ -100,13 +100,18 @@ impl Reporter {
                 total,
                 formatted,
                 unchanged,
-                skipped,
+                would_change,
                 failed,
                 duration,
             } => {
                 if !self.config.is_quiet() || failed > 0 {
                     self.write_batch_summary(
-                        total, formatted, unchanged, skipped, failed, duration,
+                        total,
+                        formatted,
+                        unchanged,
+                        would_change,
+                        failed,
+                        duration,
                     )?;
                 }
             }
@@ -246,7 +251,7 @@ impl Reporter {
         total: usize,
         formatted: usize,
         unchanged: usize,
-        skipped: usize,
+        would_change: usize,
         failed: usize,
         duration: Duration,
     ) -> io::Result<()> {
@@ -269,8 +274,8 @@ impl Reporter {
             if unchanged > 0 {
                 writeln!(lock, "  {} unchanged", unchanged.to_string().cyan())?;
             }
-            if skipped > 0 {
-                writeln!(lock, "  {} skipped", skipped.to_string().yellow())?;
+            if would_change > 0 {
+                writeln!(lock, "  {} would change", would_change.to_string().yellow())?;
             }
             if failed > 0 {
                 writeln!(lock, "  {} failed", failed.to_string().red())?;
@@ -295,8 +300,8 @@ impl Reporter {
         if unchanged > 0 {
             writeln!(lock, "  {} unchanged", unchanged)?;
         }
-        if skipped > 0 {
-            writeln!(lock, "  {} skipped", skipped)?;
+        if would_change > 0 {
+            writeln!(lock, "  {} would change", would_change)?;
         }
         if failed > 0 {
             writeln!(lock, "  {} failed", failed)?;


### PR DESCRIPTION
Fixes #69

## Summary

- `fy format <directory>` without `-i` or `--dry-run` now returns an error: `use -i to format files in-place or --dry-run to preview changes`. Previously it silently called `parse_files` instead of `format_files`, making all files appear unchanged.
- `fy format --dry-run` now reports `N would change` instead of `N skipped`. "Skipped" semantically means "not a YAML file / intentionally ignored", which was misleading.
- `BatchSummary` event field renamed from `skipped` to `would_change` to accurately represent dry-run semantics.

## Test plan

- [ ] `cargo nextest run --workspace --exclude fast-yaml --exclude fast-yaml-nodejs` — 869 tests pass
- [ ] `cargo +nightly fmt --check` — no formatting issues
- [ ] `cargo clippy ... -- -D warnings` — no warnings
- [ ] `cargo deny check` — no advisories
- [ ] Manual: `fy format tests/fixtures/` without flags returns error
- [ ] Manual: `fy format --dry-run tests/fixtures/` reports "N would change"
- [ ] Manual: `fy format -i tests/fixtures/` still works (formats in-place)