### PR TITLE
fix(core): fix formatter regression producing invalid YAML (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Core**: Mixed-case YAML 1.2.2 boolean/null variants (`True`, `TRUE`, `False`, `FALSE`, `Null`) are now correctly parsed as `Bool`/`Null` values instead of strings. saphyr only handles lowercase variants natively; the parser now post-processes the value tree to canonicalize the remaining Core Schema variants. (#71)
 - **Linter**: `empty-values` rule no longer reports a false positive for values with explicit YAML type tags (`!!null null`, `!!str value`, `!!int 42`, etc.). Any value starting with `!` is now treated as explicitly typed. (#72)
+- `fy format` no longer produces trailing spaces on mapping keys whose value is a nested collection
+  (`parent: \n` → `parent:\n`). Root cause: the space after `:` was emitted unconditionally; it is
+  now deferred and only written when the next event is a scalar value. (#75)
+- `fy format` no longer double-indents the first key of a mapping that opens inside a sequence item
+  (`-     uses:` → `- uses:`). Root cause: after writing `"- "` for a sequence item, `write_indent`
+  was still called for the first mapping key, adding a redundant level of indentation. (#75)
 - `fy format` no longer changes float type to integer: `1.0` stays `1.0` (not `1`), `1.23e10` stays `1.23e10` (not `12300000000`). Root cause: streaming formatter now handles all input sizes, preserving the original scalar text representation from the parser. Previously, inputs smaller than 1 KB fell back to DOM-based formatting which lost float precision through Rust's float Display trait.
 - `fy format` output now consistently ends with a trailing newline (POSIX convention).
 - `fy format` now preserves all documents in multi-document YAML streams (issue #65)

--- a/crates/fast-yaml-core/src/emitter.rs
+++ b/crates/fast-yaml-core/src/emitter.rs
@@ -1360,4 +1360,65 @@ mod tests {
             "Exactly two separators for two docs"
         );
     }
+
+    // Regression tests for issue #75: formatter must not produce trailing spaces
+    // or double-indented sequence-of-mapping keys.
+
+    #[cfg(feature = "streaming")]
+    #[test]
+    fn test_format_nested_mapping_no_trailing_space() {
+        // "parent:\n  child: value" — the colon after "parent" must not be followed
+        // by a space when the value is a nested mapping.
+        let result = Emitter::format("parent:\n  child: value\n").unwrap();
+        assert!(
+            !result.contains("parent: \n"),
+            "trailing space after key with nested value, got: {result:?}"
+        );
+        assert!(
+            result.contains("parent:\n"),
+            "parent key must be followed by newline without space, got: {result:?}"
+        );
+        assert!(
+            result.contains("child: value"),
+            "child key-value must be preserved, got: {result:?}"
+        );
+    }
+
+    #[cfg(feature = "streaming")]
+    #[test]
+    fn test_format_sequence_of_mappings_indent() {
+        // Steps with mapping items — first key of each item must align with the key,
+        // not be indented an extra level beyond "- ".
+        let yaml = "steps:\n  - uses: actions/checkout@v4\n  - name: Install Rust\n    uses: dtolnay/rust-toolchain@stable\n";
+        let result = Emitter::format(yaml).unwrap();
+        assert!(
+            !result.contains("-     "),
+            "sequence item keys must not be double-indented, got: {result:?}"
+        );
+        assert!(
+            result.contains("- uses:"),
+            "first item key must directly follow dash, got: {result:?}"
+        );
+        assert!(
+            result.contains("uses: actions/checkout@v4"),
+            "got: {result:?}"
+        );
+        assert!(
+            result.contains("uses: dtolnay/rust-toolchain@stable"),
+            "got: {result:?}"
+        );
+    }
+
+    #[cfg(feature = "streaming")]
+    #[test]
+    fn test_format_sequence_of_mappings_valid_yaml() {
+        // Output must parse back to the same structure (no trailing spaces breaking YAML).
+        let yaml = "steps:\n  - uses: actions/checkout@v4\n  - name: Install Rust\n    uses: dtolnay/rust-toolchain@stable\n";
+        let result = Emitter::format(yaml).unwrap();
+        let reparsed = crate::Parser::parse_str(&result);
+        assert!(
+            reparsed.is_ok(),
+            "formatted output is invalid YAML: {result:?}"
+        );
+    }
 }

--- a/crates/fast-yaml-core/src/streaming/formatter.rs
+++ b/crates/fast-yaml-core/src/streaming/formatter.rs
@@ -17,6 +17,7 @@ use crate::emitter::EmitterConfig;
 /// This struct contains ALL formatting logic and is parameterized over
 /// the backend type `B: FormatterBackend`. Through monomorphization,
 /// this compiles to specialized code for each backend with zero runtime cost.
+#[allow(clippy::struct_excessive_bools)]
 pub struct StreamingFormatter<'a, B: FormatterBackend> {
     config: &'a EmitterConfig,
     output: String,
@@ -26,6 +27,12 @@ pub struct StreamingFormatter<'a, B: FormatterBackend> {
     /// Tracks whether the last character written was a newline.
     /// Avoids O(n) `ends_with` scans by maintaining state.
     last_char_newline: bool,
+    /// Space after mapping key colon is deferred until the value is known.
+    /// Cleared without emitting when the value is a nested collection.
+    pending_space: bool,
+    /// The first key of a mapping opened inline after "- " must not call
+    /// `write_indent` — the dash already placed the cursor at the right column.
+    first_key_after_dash: bool,
     /// Backend providing context stack and anchor storage
     backend: B,
 }
@@ -45,6 +52,8 @@ impl<'a, B: FormatterBackend> StreamingFormatter<'a, B> {
             indent_level: 0,
             pending_newline: false,
             last_char_newline: true, // Empty buffer conceptually "ends with" newline
+            pending_space: false,
+            first_key_after_dash: false,
             backend,
         }
     }
@@ -162,10 +171,21 @@ impl<'a, B: FormatterBackend> StreamingFormatter<'a, B> {
                 self.last_char_newline = false;
             }
             Context::MappingKey => {
-                self.write_indent();
+                if self.first_key_after_dash {
+                    self.first_key_after_dash = false;
+                } else {
+                    self.write_indent();
+                }
             }
-            // Root level scalar and mapping value need no prefix
-            Context::Root | Context::MappingValue => {}
+            // Root level scalar needs no prefix; mapping value emits pending space
+            Context::Root => {}
+            Context::MappingValue => {
+                if self.pending_space {
+                    self.output.push(' ');
+                    self.pending_space = false;
+                    self.last_char_newline = false;
+                }
+            }
         }
 
         // Handle anchor if present (with bounds check for security)
@@ -182,8 +202,10 @@ impl<'a, B: FormatterBackend> StreamingFormatter<'a, B> {
                 if let Some(last) = self.backend.context_stack_mut().last_mut() {
                     *last = Context::MappingValue;
                 }
-                // Add space after colon for simple values
-                self.output.push(' ');
+                // Defer the space — emitted only when the value is a scalar.
+                // If the value is a nested collection, pending_space is cleared
+                // without emitting so we avoid a trailing space before the newline.
+                self.pending_space = true;
                 self.last_char_newline = false;
             }
             Context::MappingValue => {
@@ -278,7 +300,8 @@ impl<'a, B: FormatterBackend> StreamingFormatter<'a, B> {
                 self.write_indent();
             }
             Context::MappingValue => {
-                // Value position - newline and indent for nested sequence
+                // Value position - discard pending space and emit newline instead
+                self.pending_space = false;
                 self.output.push('\n');
                 self.last_char_newline = true;
             }
@@ -323,13 +346,16 @@ impl<'a, B: FormatterBackend> StreamingFormatter<'a, B> {
                 self.write_indent();
                 self.output.push_str("- ");
                 self.last_char_newline = false;
+                // The first key of this mapping sits right after "- "; no extra indent.
+                self.first_key_after_dash = true;
             }
             Context::MappingKey => {
                 // Mapping as mapping key - unusual but valid (complex key)
                 self.write_indent();
             }
             Context::MappingValue => {
-                // Value position - newline for nested mapping
+                // Value position - discard pending space and emit newline instead
+                self.pending_space = false;
                 self.output.push('\n');
                 self.last_char_newline = true;
             }
@@ -378,7 +404,14 @@ impl<'a, B: FormatterBackend> StreamingFormatter<'a, B> {
             Context::MappingKey => {
                 self.write_indent();
             }
-            Context::Root | Context::MappingValue => {}
+            Context::Root => {}
+            Context::MappingValue => {
+                if self.pending_space {
+                    self.output.push(' ');
+                    self.pending_space = false;
+                    self.last_char_newline = false;
+                }
+            }
         }
 
         // Emit the alias reference
@@ -398,7 +431,7 @@ impl<'a, B: FormatterBackend> StreamingFormatter<'a, B> {
                 if let Some(last) = self.backend.context_stack_mut().last_mut() {
                     *last = Context::MappingValue;
                 }
-                self.output.push(' ');
+                self.pending_space = true;
                 // last_char_newline remains false
             }
             Context::MappingValue => {


### PR DESCRIPTION
## Summary

PR #67 introduced two latent bugs in `StreamingFormatter` that produce malformed YAML output:

- **Trailing spaces after mapping keys**: `parent: ` instead of `parent:` when the value is a nested collection
- **Broken sequence items**: `-         uses:` instead of `- uses:` in sequence-of-mappings

Both bugs caused `fy format` output to fail re-parsing.

## Root cause

`emit_scalar` unconditionally pushed a space after every mapping key. When the value was a nested collection, `start_mapping`/`start_sequence` added a `\n` on top — leaving the space dangling.

For sequence-of-mappings, `start_mapping` wrote `"- "` and bumped `indent_level`, then `write_indent()` added extra spaces on top for the first key.

## Fix

- `pending_space: bool` — defers the space after `:`, emits it only for scalar values, clears it for nested collections
- `first_key_after_dash: bool` — skips `write_indent()` for the first mapping key opened after a sequence `- ` marker

## Tests

3 regression tests added. 880/880 tests pass.

## Checklist

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo nextest run` (880 passed)
- [x] `cargo deny check`
- [x] `cargo doc`
- [x] CHANGELOG.md updated

Closes #75