### PR TITLE
fix(core): preserve block scalar clip chomp indicator in formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fy format <directory>` without `-i` now returns an error instead of silently validating files (#69)
 - `fy format --dry-run` now reports "would change: N" instead of "skipped: N" (#69)
 - Preserve block scalar styles (literal `|` and folded `>`) in `fy format` (#62)
+- **Core**: `fy format` no longer changes the chomp indicator of block scalars. `|` (clip) remains `|` and is not converted to `|-` (strip), preserving the trailing newline in the parsed value. All three chomp variants (`|`, `|-`, `|+`) and their folded equivalents are now round-tripped correctly. (#76)
 
 ### Added
 

--- a/crates/fast-yaml-core/src/emitter.rs
+++ b/crates/fast-yaml-core/src/emitter.rs
@@ -1421,4 +1421,54 @@ mod tests {
             "formatted output is invalid YAML: {result:?}"
         );
     }
+
+    // Regression tests for issue #76: chomp indicator must not change during formatting.
+
+    #[test]
+    fn test_format_preserves_clip_chomp() {
+        // `|` (clip) must remain `|`, not be converted to `|-`
+        let input = "desc: |\n  line one\n  line two\n";
+        let config = EmitterConfig::default();
+        let result = Emitter::format_with_config(input, &config).unwrap();
+        assert!(
+            result.contains("desc: |\n"),
+            "clip chomp `|` must not be changed to `|-`, got: {result}"
+        );
+    }
+
+    #[test]
+    fn test_format_preserves_strip_chomp() {
+        // `|-` (strip) must remain `|-`
+        let input = "desc: |-\n  line one\n  line two\n";
+        let config = EmitterConfig::default();
+        let result = Emitter::format_with_config(input, &config).unwrap();
+        assert!(
+            result.contains("desc: |-\n"),
+            "strip chomp `|-` must be preserved, got: {result}"
+        );
+    }
+
+    #[test]
+    fn test_format_preserves_keep_chomp() {
+        // `|+` (keep) must remain `|+` when value has trailing blank lines
+        let input = "desc: |+\n  line one\n  line two\n\n";
+        let config = EmitterConfig::default();
+        let result = Emitter::format_with_config(input, &config).unwrap();
+        assert!(
+            result.contains("desc: |+\n"),
+            "keep chomp `|+` must be preserved, got: {result}"
+        );
+    }
+
+    #[test]
+    fn test_format_preserves_folded_clip_chomp() {
+        // `>` (folded clip) must remain `>`, not be converted to `>-`
+        let input = "desc: >\n  line one\n  line two\n";
+        let config = EmitterConfig::default();
+        let result = Emitter::format_with_config(input, &config).unwrap();
+        assert!(
+            result.contains("desc: >\n"),
+            "folded clip `>` must not be changed to `>-`, got: {result}"
+        );
+    }
 }

--- a/crates/fast-yaml-core/src/streaming/formatter.rs
+++ b/crates/fast-yaml-core/src/streaming/formatter.rs
@@ -12,6 +12,21 @@ use super::traits::{AnchorStoreOps, ContextStackOps, FormatterBackend};
 use super::{Context, INDENT_SPACES, MAX_ANCHOR_ID, MAX_DEPTH};
 use crate::emitter::EmitterConfig;
 
+/// Return the YAML chomp indicator suffix for a block scalar value.
+///
+/// - `"+"` (keep) if `value` ends with two or more newlines (trailing blank lines)
+/// - `""` (clip, default) if `value` ends with exactly one newline
+/// - `"-"` (strip) if `value` does not end with a newline
+fn chomp_indicator(value: &str) -> &'static str {
+    if value.ends_with("\n\n") {
+        "+"
+    } else if value.ends_with('\n') {
+        ""
+    } else {
+        "-"
+    }
+}
+
 /// Generic streaming formatter with pluggable backend.
 ///
 /// This struct contains ALL formatting logic and is parameterized over
@@ -262,14 +277,16 @@ impl<'a, B: FormatterBackend> StreamingFormatter<'a, B> {
                 self.last_char_newline = false;
             }
             ScalarStyle::Literal => {
-                self.output.push_str("|-");
+                self.output.push('|');
+                self.output.push_str(chomp_indicator(value));
                 self.output.push('\n');
                 self.write_block_scalar_lines(value);
                 // write_block_scalar_lines always ends with newline
                 self.last_char_newline = true;
             }
             ScalarStyle::Folded => {
-                self.output.push_str(">-");
+                self.output.push('>');
+                self.output.push_str(chomp_indicator(value));
                 self.output.push('\n');
                 self.write_block_scalar_lines(value);
                 // write_block_scalar_lines always ends with newline


### PR DESCRIPTION
## Summary

Fixes #76. The `fy format` command was converting `|` (clip chomp) to `|-` (strip chomp), removing the trailing newline from the scalar value. This is a semantic change that alters the parsed content.

**Before:**
```
$ printf 'desc: |\n  line one\n  line two\n' | fy format
desc: |-
  line one
  line two
```

**After:**
```
$ printf 'desc: |\n  line one\n  line two\n' | fy format
desc: |
  line one
  line two
```

## Root Cause

In `streaming/formatter.rs`, the `ScalarStyle::Literal` and `ScalarStyle::Folded` branches unconditionally emitted `|-` and `>-`, ignoring the actual trailing-newline state of the scalar content.

## Fix

Added a `chomp_indicator` free function that derives the correct YAML chomp suffix from the content:
- `"+"` (keep) — content ends with two or more newlines
- `""` (clip, default) — content ends with exactly one newline
- `"-"` (strip) — content has no trailing newline

The non-streaming DOM path already had the correct logic; only the streaming path (used by the CLI) was affected.

## Tests

Four new regression tests in `emitter::tests` cover all three chomp variants for literal style, plus folded clip:
- `test_format_preserves_clip_chomp`
- `test_format_preserves_strip_chomp`
- `test_format_preserves_keep_chomp`
- `test_format_preserves_folded_clip_chomp`