### PR TITLE
fix(cli,core): fy convert multi-doc loss and block scalar trailing whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Linter**: `Linter::with_config()` now loads all default rules instead of an empty registry. Previously, constructing a `Linter` with a custom config silently disabled all linting rules, causing zero diagnostics regardless of input. Affects Rust, Python, and NodeJS bindings. (#86)
+- `fy convert` now correctly handles multi-document YAML streams: all documents are included in a JSON array instead of silently dropping all but the first. Single-document streams continue to produce a plain JSON object. (#87)
+- `fy format` no longer adds trailing whitespace to blank lines inside block scalars (`|`, `>`). Previously, blank lines inside a block scalar received the same indentation prefix as non-blank lines, producing `  \n` instead of `\n`. (#85)
 - **Core**: Mixed-case YAML 1.2.2 boolean/null variants (`True`, `TRUE`, `False`, `FALSE`, `Null`) are now correctly parsed as `Bool`/`Null` values instead of strings. saphyr only handles lowercase variants natively; the parser now post-processes the value tree to canonicalize the remaining Core Schema variants. (#71)
 - **Linter**: `empty-values` rule no longer reports a false positive for values with explicit YAML type tags (`!!null null`, `!!str value`, `!!int 42`, etc.). Any value starting with `!` is now treated as explicitly typed. (#72)
 - `fy format` no longer produces trailing spaces on mapping keys whose value is a nested collection

--- a/crates/fast-yaml-cli/src/commands/convert.rs
+++ b/crates/fast-yaml-cli/src/commands/convert.rs
@@ -32,13 +32,21 @@ impl ConvertCommand {
 
     /// Convert YAML to JSON
     fn yaml_to_json(&self, input: &InputSource, output: &OutputWriter) -> Result<()> {
-        // Parse YAML
-        let value = Parser::parse_str(input.as_str())
-            .context("Failed to parse YAML")?
-            .ok_or_else(|| anyhow::anyhow!("Empty YAML document"))?;
+        // Parse all YAML documents to support multi-document streams
+        let docs = Parser::parse_all(input.as_str()).context("Failed to parse YAML")?;
 
-        // Convert to serde_json::Value
-        let json_value = value_to_json(&value)?;
+        if docs.is_empty() {
+            return Err(anyhow::anyhow!("Empty YAML document"));
+        }
+
+        let json_value = if docs.len() == 1 {
+            // Single document: preserve existing behaviour (plain object/value)
+            value_to_json(&docs[0])?
+        } else {
+            // Multi-document stream: output a JSON array
+            let arr: Result<Vec<_>> = docs.iter().map(value_to_json).collect();
+            serde_json::Value::Array(arr?)
+        };
 
         // Serialize to JSON
         let mut json_string = if self.pretty {
@@ -266,5 +274,33 @@ mod tests {
         let config = CommonConfig::new();
         let cmd = ConvertCommand::new(config, ConvertFormat::Yaml, true);
         assert!(cmd.execute(&input, &output).is_err());
+    }
+
+    #[test]
+    fn test_multi_document_yaml_to_json() {
+        let input = InputSource {
+            content: "---\nfoo: 1\n---\nbar: 2\n---\nbaz: 3\n".to_string(),
+            origin: InputOrigin::Stdin,
+        };
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_path = temp_dir.path().join("output.json");
+        let output = OutputWriter::from_args(Some(temp_path.clone()), false, None).unwrap();
+
+        let config = CommonConfig::new();
+        let cmd = ConvertCommand::new(config, ConvertFormat::Json, false);
+        assert!(cmd.execute(&input, &output).is_ok());
+
+        let json_str = std::fs::read_to_string(&temp_path).unwrap();
+        let json: serde_json::Value = serde_json::from_str(json_str.trim()).unwrap();
+        assert!(
+            json.is_array(),
+            "Expected JSON array for multi-document stream"
+        );
+        let arr = json.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0]["foo"], 1);
+        assert_eq!(arr[1]["bar"], 2);
+        assert_eq!(arr[2]["baz"], 3);
     }
 }

--- a/crates/fast-yaml-core/src/streaming/formatter.rs
+++ b/crates/fast-yaml-core/src/streaming/formatter.rs
@@ -470,12 +470,16 @@ impl<'a, B: FormatterBackend> StreamingFormatter<'a, B> {
         let indent_chars = self.indent_level.saturating_mul(self.config.indent);
 
         for line in value.lines() {
-            if indent_chars <= INDENT_SPACES.len() {
-                self.output.push_str(&INDENT_SPACES[..indent_chars]);
-            } else {
-                self.output.push_str(&" ".repeat(indent_chars));
+            // Blank lines inside block scalars must not receive indentation — that
+            // would create trailing whitespace, which is a lint violation.
+            if !line.is_empty() {
+                if indent_chars <= INDENT_SPACES.len() {
+                    self.output.push_str(&INDENT_SPACES[..indent_chars]);
+                } else {
+                    self.output.push_str(&" ".repeat(indent_chars));
+                }
+                self.output.push_str(line);
             }
-            self.output.push_str(line);
             self.output.push('\n');
         }
     }


### PR DESCRIPTION
## Summary

- **#87**: `fy convert` now correctly handles multi-document YAML streams. All documents are converted and returned as a JSON array instead of silently dropping all but the first document. Single-document streams continue to produce a plain JSON object, preserving backward compatibility.
- **#85**: `fy format` no longer produces trailing whitespace on blank lines inside block scalars (`|`, `>`). The streaming formatter was adding the full indentation prefix to empty lines, producing `  \n` instead of `\n`.

## Changes

- `crates/fast-yaml-cli/src/commands/convert.rs`: replace `Parser::parse_str` with `Parser::parse_all` in `yaml_to_json`; wrap multiple docs in `serde_json::Value::Array`. Added regression test `test_multi_document_yaml_to_json`.
- `crates/fast-yaml-core/src/streaming/formatter.rs`: in `write_block_scalar_lines`, skip indentation push for empty lines.

## Test plan

- [ ] `cargo nextest run --workspace --exclude fast-yaml --exclude fast-yaml-nodejs` — all 901 tests pass
- [ ] `cargo +nightly fmt --check` — no formatting diff
- [ ] `cargo clippy --workspace --all-targets --all-features --exclude fast-yaml --exclude fast-yaml-nodejs -- -D warnings` — no warnings
- [ ] Manual: `printf '---\nfoo: 1\n---\nbar: 2\n' | fy convert json /dev/stdin` outputs `[{"foo":1},{"bar":2}]`
- [ ] Manual: `fy format` on a `|+` block scalar with blank lines produces no trailing whitespace

Closes #87
Closes #85