### PR TITLE
fix(linter): rewrite duplicate-key rule with event-based parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Linter**: `duplicate-key` rule now detects duplicate keys at all nesting levels, not only at the top-level mapping. Previously, duplicates inside nested mappings were silently ignored. (#96)
+- **Linter**: `duplicate-key` rule no longer emits the same diagnostic twice for a single duplicate key occurrence. The rule was rewritten to use event-based parsing (saphyr-parser) instead of source-text scanning, which also eliminates potential false positives from key names appearing in values or comments. (#97)
 - `Emitter::emit_str` and `emit_str_with_config` now always append a trailing newline, consistent with `emit_all_with_config` and POSIX text file convention. Affects `safe_dump`/`safeDump` in Python and NodeJS bindings. (#94)
 - `fy format` and `Emitter::format_str` now preserve `%YAML` and `%TAG` directives. Previously they were silently dropped because saphyr does not round-trip directives through its AST. (#95)
 - **Linter**: `DuplicateKeysRule` / `SourceMapper` now builds a full inverted key index in a single O(n) pass on first use instead of scanning all source lines for every unique key (O(n²)). `fy lint` performance on large files (Kubernetes manifests, OpenAPI specs) improves from unusable (37s for 10 000 keys) to near-linear. (#100)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,7 @@ dependencies = [
  "fast-yaml-core",
  "indoc",
  "is-terminal",
+ "saphyr-parser",
  "serde",
  "serde_json",
  "thiserror",

--- a/crates/fast-yaml-linter/Cargo.toml
+++ b/crates/fast-yaml-linter/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["development-tools", "parsing"]
 [dependencies]
 fast-yaml-core = { workspace = true }
 is-terminal = { workspace = true }
+saphyr-parser = { workspace = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }

--- a/crates/fast-yaml-linter/src/rules/duplicate_keys.rs
+++ b/crates/fast-yaml-linter/src/rules/duplicate_keys.rs
@@ -1,23 +1,18 @@
 //! Rule to detect duplicate keys in YAML mappings.
 
-use crate::{
-    Diagnostic, DiagnosticBuilder, DiagnosticCode, LintConfig, LintContext, Severity,
-    source::SourceMapper,
-};
+use crate::{Diagnostic, DiagnosticBuilder, DiagnosticCode, LintConfig, LintContext, Severity};
 use fast_yaml_core::Value;
+use saphyr_parser::{BufferedInput, Event, Parser as SaphyrParser};
+use std::collections::HashMap;
 
 /// Rule to detect duplicate keys in YAML mappings.
 ///
-/// This rule scans the source text directly to find duplicate keys at the top level
-/// that would be silently deduplicated by the parser. While YAML 1.2 allows duplicate
-/// keys, keeping the last value, this is often a mistake that should be reported.
+/// Detects duplicate keys at all nesting levels by processing raw YAML events before
+/// the parser deduplicates them. Each duplicate key occurrence produces exactly one
+/// diagnostic pointing to the duplicate, with a note referencing the first definition.
 ///
-/// **Scope**: Only checks top-level keys to avoid false positives from nested mappings
-/// or array elements with the same key names. Nested mappings should use unique keys
-/// within their own context naturally.
-///
-/// Duplicate keys can lead to unexpected behavior where later values
-/// silently override earlier ones without warning.
+/// Duplicate keys cause silent data loss — most parsers keep the last value, silently
+/// discarding earlier ones. This rule detects them per-mapping-scope at all depths.
 pub struct DuplicateKeysRule;
 
 impl super::LintRule for DuplicateKeysRule {
@@ -30,75 +25,146 @@ impl super::LintRule for DuplicateKeysRule {
     }
 
     fn description(&self) -> &'static str {
-        "Detects duplicate keys in YAML mappings, which violate the YAML 1.2 specification"
+        "Detects duplicate keys in YAML mappings at all nesting levels"
     }
 
     fn default_severity(&self) -> Severity {
         Severity::Error
     }
 
-    fn check(&self, context: &LintContext, value: &Value, config: &LintConfig) -> Vec<Diagnostic> {
-        let source = context.source();
+    fn check(&self, context: &LintContext, _value: &Value, config: &LintConfig) -> Vec<Diagnostic> {
         if config.allow_duplicate_keys {
             return Vec::new();
         }
-
-        let mut diagnostics = Vec::new();
-        let mut mapper = SourceMapper::new(source);
-        // Only check top-level mapping to avoid false positives from nested contexts
-        check_top_level(source, value, &mut diagnostics, &mut mapper);
-        diagnostics
+        scan_duplicate_keys(context.source())
     }
 }
 
-fn check_top_level(
-    source: &str,
-    value: &Value,
-    diagnostics: &mut Vec<Diagnostic>,
-    mapper: &mut SourceMapper,
-) {
-    // Only check top-level mapping for duplicate keys
-    if let Value::Mapping(map) = value {
-        // Get unique keys from the (deduplicated) AST map
-        let unique_keys: Vec<String> = map
-            .iter()
-            .filter_map(|(k, _)| k.as_str().map(String::from))
-            .collect();
+/// Scope stack entry to track mapping vs sequence nesting.
+enum ScopeKind {
+    /// A YAML mapping. Tracks seen keys and whether the next scalar is a key.
+    Mapping {
+        seen: HashMap<String, (usize, usize)>, // key → (1-indexed line, 1-indexed col)
+        expecting_key: bool,
+    },
+    /// A YAML sequence. No key tracking needed.
+    Sequence,
+}
 
-        // For each unique key, find ALL occurrences in source and detect duplicates.
-        // Filter to column 1 (zero indentation) to avoid false positives from nested keys.
-        for key_str in &unique_keys {
-            let all_spans: Vec<_> = mapper
-                .find_all_key_spans(key_str)
-                .into_iter()
-                .filter(|s| s.start.column == 1)
-                .collect();
+/// Parses raw YAML events and collects duplicate key occurrences.
+///
+/// Returns a list of `(key, first_line, dup_line, dup_col)` (all 1-indexed).
+fn collect_duplicates(source: &str) -> Vec<(String, usize, usize, usize)> {
+    let mut duplicates: Vec<(String, usize, usize, usize)> = Vec::new();
+    let mut scopes: Vec<ScopeKind> = Vec::new();
 
-            // If we find more than one occurrence, all after the first are duplicates
-            if all_spans.len() > 1 {
-                let first_span = all_spans[0];
-                for duplicate_span in &all_spans[1..] {
-                    let diagnostic = DiagnosticBuilder::new(
-                        DiagnosticCode::DUPLICATE_KEY,
-                        Severity::Error,
-                        format!(
-                            "duplicate key '{}' (first defined at line {})",
-                            key_str, first_span.start.line
-                        ),
-                        *duplicate_span,
-                    )
-                    .with_suggestion(
-                        "remove this duplicate key or rename it",
-                        *duplicate_span,
-                        None,
-                    )
-                    .build(source);
+    let input = BufferedInput::new(source.chars());
+    let mut parser = SaphyrParser::new(input);
 
-                    diagnostics.push(diagnostic);
+    while let Some(Ok(ev)) = parser.next_event() {
+        let (event, span) = ev;
+
+        match event {
+            Event::MappingStart(..) => {
+                scopes.push(ScopeKind::Mapping {
+                    seen: HashMap::new(),
+                    expecting_key: true,
+                });
+            }
+
+            Event::MappingEnd => {
+                scopes.pop();
+                // The mapping was a value in the parent scope; parent now expects the next key.
+                advance_parent_to_key(&mut scopes);
+            }
+
+            Event::SequenceStart(..) => {
+                scopes.push(ScopeKind::Sequence);
+            }
+
+            Event::SequenceEnd => {
+                scopes.pop();
+                // The sequence was a value; parent now expects the next key.
+                advance_parent_to_key(&mut scopes);
+            }
+
+            Event::Scalar(ref value, ..) => {
+                // saphyr Marker: line() and col() are 1-indexed.
+                let scalar_line = span.start.line();
+                let scalar_col = span.start.col();
+
+                match scopes.last_mut() {
+                    Some(ScopeKind::Mapping {
+                        seen,
+                        expecting_key,
+                    }) => {
+                        if *expecting_key {
+                            let key = value.as_ref().to_owned();
+                            if let Some(&(first_line, _)) = seen.get(&key) {
+                                duplicates.push((key, first_line, scalar_line, scalar_col));
+                            } else {
+                                seen.insert(key, (scalar_line, scalar_col));
+                            }
+                            *expecting_key = false; // next scalar in this mapping is a value
+                        } else {
+                            *expecting_key = true; // value consumed, next is a key
+                        }
+                    }
+                    Some(ScopeKind::Sequence) | None => {
+                        // No key/value alternation for sequences or top-level scalars.
+                    }
                 }
             }
+
+            _ => {}
         }
     }
+
+    duplicates
+}
+
+/// After a nested mapping or sequence ends, the parent mapping (if any) should
+/// advance to expecting its next key.
+const fn advance_parent_to_key(scopes: &mut [ScopeKind]) {
+    if let Some(ScopeKind::Mapping { expecting_key, .. }) = scopes.last_mut() {
+        *expecting_key = true;
+    }
+}
+
+fn scan_duplicate_keys(source: &str) -> Vec<Diagnostic> {
+    collect_duplicates(source)
+        .into_iter()
+        .map(|(key, first_line, dup_line, dup_col)| {
+            let span = span_for_key(source, dup_line, dup_col, key.len());
+            DiagnosticBuilder::new(
+                DiagnosticCode::DUPLICATE_KEY,
+                Severity::Error,
+                format!("duplicate key '{key}' (first defined at line {first_line})"),
+                span,
+            )
+            .with_suggestion("remove this duplicate key or rename it", span, None)
+            .build(source)
+        })
+        .collect()
+}
+
+/// Constructs a [`crate::Span`] for a key at the given 1-indexed line and column.
+fn span_for_key(source: &str, line: usize, col: usize, key_len: usize) -> crate::Span {
+    use crate::{Location, Span};
+
+    let line_start_offset: usize = source
+        .lines()
+        .take(line.saturating_sub(1))
+        .map(|l| l.len() + 1) // +1 for the newline byte
+        .sum();
+
+    let col_offset = col.saturating_sub(1);
+    let start_offset = line_start_offset + col_offset;
+
+    Span::new(
+        Location::new(line, col, start_offset),
+        Location::new(line, col + key_len, start_offset + key_len),
+    )
 }
 
 #[cfg(test)]
@@ -107,136 +173,98 @@ mod tests {
     use crate::rules::LintRule;
     use fast_yaml_core::Parser;
 
-    #[test]
-    fn test_no_duplicate_keys() {
-        let yaml = "name: John\nage: 30\ncity: NYC";
-        let value = Parser::parse_str(yaml).unwrap().unwrap();
-
-        let rule = DuplicateKeysRule;
-        let config = LintConfig::default();
-        let context = LintContext::new(yaml);
-        let diagnostics = rule.check(&context, &value, &config);
-
-        assert!(diagnostics.is_empty());
-    }
-
-    #[test]
-    fn test_duplicate_keys_detected() {
-        // The linter now scans source directly to find duplicates
-        // even though the parser deduplicates them
-        let yaml = "name: John\nage: 30\nname: Jane";
-
-        let value = Parser::parse_str(yaml).unwrap().unwrap();
-
-        // Verify saphyr deduplicates and keeps the last value
-        if let Value::Mapping(map) = &value {
-            // Only 2 keys should remain (age and name)
-            assert_eq!(map.len(), 2);
-
-            let name_val = map
-                .iter()
-                .find(|(k, _)| k.as_str() == Some("name"))
-                .map(|(_, v)| v.as_str());
-            assert_eq!(name_val, Some(Some("Jane")));
-        } else {
-            panic!("Expected mapping");
-        }
-
-        // The linter should detect the duplicate by scanning source
-        // but rule is disabled by default, so enable it explicitly
+    fn run(yaml: &str) -> Vec<Diagnostic> {
+        let value = Parser::parse_str(yaml)
+            .unwrap()
+            .unwrap_or(Value::Value(fast_yaml_core::ScalarOwned::Null));
         let rule = DuplicateKeysRule;
         let config = LintConfig {
             allow_duplicate_keys: false,
             ..Default::default()
         };
-        let context = LintContext::new(yaml);
-        let diagnostics = rule.check(&context, &value, &config);
+        rule.check(&LintContext::new(yaml), &value, &config)
+    }
 
-        // Should find one duplicate
-        assert_eq!(diagnostics.len(), 1);
-        assert!(diagnostics[0].message.contains("duplicate key 'name'"));
-        assert_eq!(diagnostics[0].span.start.line, 3);
+    #[test]
+    fn test_no_duplicate_keys() {
+        assert!(run("name: John\nage: 30\ncity: NYC").is_empty());
+    }
+
+    #[test]
+    fn test_top_level_duplicate_emits_exactly_one_diagnostic() {
+        let diags = run("key: first\nkey: second\n");
+        assert_eq!(diags.len(), 1, "expected 1 diagnostic, got {}", diags.len());
+        assert!(diags[0].message.contains("duplicate key 'key'"));
+        assert_eq!(diags[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn test_triple_duplicate_emits_two_diagnostics() {
+        assert_eq!(run("key: a\nkey: b\nkey: c\n").len(), 2);
+    }
+
+    #[test]
+    fn test_nested_duplicate_detected() {
+        let diags = run("top:\n  key: 1\n  key: 2\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("duplicate key 'key'"));
+    }
+
+    #[test]
+    fn test_deeply_nested_duplicate_detected() {
+        let diags = run("parent:\n  child:\n    nested: a\n    nested: b\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("duplicate key 'nested'"));
+    }
+
+    #[test]
+    fn test_same_key_in_different_scopes_is_valid() {
+        assert!(run("parent:\n  name: parent_value\nchild:\n  name: child_value\n").is_empty());
+    }
+
+    #[test]
+    fn test_top_and_nested_duplicates() {
+        let diags = run("key: first\nkey: second\ntop:\n  dup: 1\n  dup: 2\n");
+        assert_eq!(diags.len(), 2);
     }
 
     #[test]
     fn test_allow_duplicate_keys_config() {
-        let yaml = "name: John\nage: 30\ncity: NYC";
-        let value = Parser::parse_str(yaml).unwrap().unwrap();
-
-        let rule = DuplicateKeysRule;
+        let value = Parser::parse_str("key: first\nkey: second\n")
+            .unwrap()
+            .unwrap();
         let config = LintConfig {
             allow_duplicate_keys: true,
             ..Default::default()
         };
-        let context = LintContext::new(yaml);
-        let diagnostics = rule.check(&context, &value, &config);
-
-        assert!(diagnostics.is_empty());
+        assert!(
+            DuplicateKeysRule
+                .check(
+                    &LintContext::new("key: first\nkey: second\n"),
+                    &value,
+                    &config
+                )
+                .is_empty()
+        );
     }
 
     #[test]
-    fn test_nested_same_keys_are_valid() {
-        let yaml = "
-parent:
-  name: parent_value
-child:
-  name: child_value
-another:
-  nested:
-    name: nested_value
-";
-        let value = Parser::parse_str(yaml).unwrap().unwrap();
-
-        let rule = DuplicateKeysRule;
-        let config = LintConfig::default();
-        let context = LintContext::new(yaml);
-        let diagnostics = rule.check(&context, &value, &config);
-
-        // Same key names in different nested scopes should not trigger errors
-        // (rule only checks top-level keys)
-        assert!(diagnostics.is_empty());
+    fn test_array_of_mappings_same_keys_valid() {
+        let yaml = "users:\n  - name: Alice\n    age: 30\n  - name: Bob\n    age: 25\n";
+        assert!(run(yaml).is_empty());
     }
 
     #[test]
-    fn test_keys_in_different_mappings() {
-        let yaml = "
-user1:
-  id: 1
-  email: user1@example.com
-user2:
-  id: 2
-  email: user2@example.com
-";
-        let value = Parser::parse_str(yaml).unwrap().unwrap();
-
-        let rule = DuplicateKeysRule;
-        let config = LintConfig::default();
-        let context = LintContext::new(yaml);
-        let diagnostics = rule.check(&context, &value, &config);
-
-        // Keys 'id' and 'email' appear in different mappings, which is valid
-        assert!(diagnostics.is_empty());
+    fn test_keys_in_different_mappings_valid() {
+        let yaml = "user1:\n  id: 1\n  email: a@b.com\nuser2:\n  id: 2\n  email: c@d.com\n";
+        assert!(run(yaml).is_empty());
     }
 
     #[test]
-    fn test_array_of_mappings_with_same_keys() {
-        let yaml = "
-users:
-  - name: Alice
-    age: 30
-  - name: Bob
-    age: 25
-  - name: Charlie
-    age: 35
-";
-        let value = Parser::parse_str(yaml).unwrap().unwrap();
-
-        let rule = DuplicateKeysRule;
-        let config = LintConfig::default();
-        let context = LintContext::new(yaml);
-        let diagnostics = rule.check(&context, &value, &config);
-
-        // Same keys in array items are valid
-        assert!(diagnostics.is_empty());
+    fn test_first_defined_line_in_message() {
+        let diags = run("name: John\nage: 30\nname: Jane\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("first defined at line 1"));
+        assert_eq!(diags[0].span.start.line, 3);
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #97: `duplicate-key` rule was emitting the same diagnostic twice per occurrence
- Fixes #96: nested duplicate keys were silently ignored; only top-level mapping was checked

The rule is rewritten using `saphyr-parser` event streaming. A scope stack tracks seen keys per mapping level, processing raw YAML events before saphyr deduplicates them. This approach:

- Emits exactly one diagnostic per duplicate key occurrence
- Detects duplicates at all nesting depths
- Eliminates false positives from key names appearing in values or comments

`saphyr-parser` is added as a direct dependency of `fast-yaml-linter`.

## Test plan

- [ ] `cargo nextest run -p fast-yaml-linter` — all 336 tests pass
- [ ] New tests cover: single top-level duplicate, triple duplicate (2 diagnostics), nested duplicate, deeply nested duplicate, same key in different scopes (no false positive), arrays of mappings (no false positive)
- [ ] `cargo clippy --workspace ... -- -D warnings` — clean