### PR TITLE
fix(linter): braces/brackets wrong location and false positives on template expressions (#102, #103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Linter**: `braces`/`brackets` rules no longer fire on template expressions (Jinja2, GitHub Actions `${{ }}`) inside plain scalar values. Previously the rules scanned raw source text and matched `{`/`[` inside string values, causing false-positive spam on workflow files. The tokenizer now tracks block-context plain scalars and skips flow-syntax characters inside them. (#103)
+- **Linter**: `braces`/`brackets` rules now report diagnostics at the correct source location (the `{`/`[` or `}`/`]` token) instead of always reporting line 1, column 1. (#102)
 - **Linter**: `duplicate-key` rule now detects duplicate keys at all nesting levels, not only at the top-level mapping. Previously, duplicates inside nested mappings were silently ignored. (#96)
 - **Linter**: `duplicate-key` rule no longer emits the same diagnostic twice for a single duplicate key occurrence. The rule was rewritten to use event-based parsing (saphyr-parser) instead of source-text scanning, which also eliminates potential false positives from key names appearing in values or comments. (#97)
 - `Emitter::emit_str` and `emit_str_with_config` now always append a trailing newline, consistent with `emit_all_with_config` and POSIX text file convention. Affects `safe_dump`/`safeDump` in Python and NodeJS bindings. (#94)

--- a/crates/fast-yaml-linter/src/rules/braces.rs
+++ b/crates/fast-yaml-linter/src/rules/braces.rs
@@ -155,6 +155,7 @@ impl super::LintRule for BracesRule {
                     self.code(),
                     config,
                     "braces",
+                    open.span,
                 ) {
                     diagnostics.push(diag);
                 }
@@ -169,6 +170,7 @@ impl super::LintRule for BracesRule {
                     self.code(),
                     config,
                     "braces",
+                    close.span,
                 ) {
                     diagnostics.push(diag);
                 }
@@ -349,5 +351,89 @@ mod tests {
         assert!(is_empty_collection("{}", 1, 1));
         assert!(is_empty_collection("{  }", 1, 3));
         assert!(!is_empty_collection("{a}", 1, 2));
+    }
+
+    // Regression test for issue #102: location must not be hardcoded to 1:1
+    #[test]
+    fn test_braces_correct_location() {
+        let yaml = "key: {  a: 1  }";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = BracesRule;
+        let config = LintConfig::new().with_rule_config(
+            "braces",
+            RuleConfig::new().with_option("max-spaces-inside", 0i64),
+        );
+
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &config);
+        assert!(!diagnostics.is_empty());
+        // The opening-side diagnostic must point to the `{`, not line 1 col 1
+        let open_diag = diagnostics.iter().find(|d| d.span.start.offset > 0);
+        assert!(open_diag.is_some(), "diagnostic must have non-zero offset");
+        // None of the diagnostics should report line 1 col 1 (offset 0)
+        for d in &diagnostics {
+            assert!(
+                d.span.start.offset > 0,
+                "diagnostic at wrong location: {:?}",
+                d.span,
+            );
+        }
+    }
+
+    // Regression test for issue #102: each violation fires only once
+    #[test]
+    fn test_braces_no_duplicate_diagnostics() {
+        let yaml = "key: { a: 1 }";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = BracesRule;
+        let config = LintConfig::new().with_rule_config(
+            "braces",
+            RuleConfig::new().with_option("max-spaces-inside", 0i64),
+        );
+
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &config);
+        // Two violations: space after `{` and space before `}`
+        assert_eq!(diagnostics.len(), 2);
+        // They must point to different locations
+        assert_ne!(
+            diagnostics[0].span.start.offset,
+            diagnostics[1].span.start.offset
+        );
+    }
+
+    // Regression test for issue #103: no false positives on template expressions
+    #[test]
+    fn test_braces_no_false_positive_on_template_expression() {
+        let yaml = "key: ${{ github.ref }}";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = BracesRule;
+        let config = LintConfig::default();
+
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &config);
+        assert!(
+            diagnostics.is_empty(),
+            "unexpected diagnostics on template expression: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn test_braces_no_false_positive_jinja2() {
+        let yaml = "template: \"{{ variable }}\"";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = BracesRule;
+        let config = LintConfig::default();
+
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &config);
+        assert!(
+            diagnostics.is_empty(),
+            "unexpected diagnostics on Jinja2-style template: {diagnostics:?}"
+        );
     }
 }

--- a/crates/fast-yaml-linter/src/rules/brackets.rs
+++ b/crates/fast-yaml-linter/src/rules/brackets.rs
@@ -155,6 +155,7 @@ impl super::LintRule for BracketsRule {
                     self.code(),
                     config,
                     "brackets",
+                    open.span,
                 ) {
                     diagnostics.push(diag);
                 }
@@ -169,6 +170,7 @@ impl super::LintRule for BracketsRule {
                     self.code(),
                     config,
                     "brackets",
+                    close.span,
                 ) {
                     diagnostics.push(diag);
                 }

--- a/crates/fast-yaml-linter/src/rules/flow_common.rs
+++ b/crates/fast-yaml-linter/src/rules/flow_common.rs
@@ -1,7 +1,7 @@
 //! Common utilities for flow collection rules (braces, brackets).
 
 use crate::{
-    LintConfig, Location, Severity, Span,
+    LintConfig, Severity, Span,
     diagnostic::{Diagnostic, DiagnosticBuilder},
 };
 
@@ -55,6 +55,7 @@ pub fn check_spaces_after_opening(
     code: &str,
     config: &LintConfig,
     collection_name: &str,
+    opening_span: Span,
 ) -> Option<Diagnostic> {
     if start_offset >= source.len() {
         return None;
@@ -72,9 +73,6 @@ pub fn check_spaces_after_opening(
 
     if min_spaces >= 0 && spaces_i64 < min_spaces {
         let severity = config.get_effective_severity(code, Severity::Warning);
-        let loc = Location::new(1, 1, start_offset);
-        let span = Span::new(loc, loc);
-
         return Some(
             DiagnosticBuilder::new(
                 code,
@@ -82,7 +80,7 @@ pub fn check_spaces_after_opening(
                 format!(
                     "too few spaces inside {collection_name} (expected at least {min_spaces}, found {spaces})"
                 ),
-                span,
+                opening_span,
             )
             .build(source),
         );
@@ -90,9 +88,6 @@ pub fn check_spaces_after_opening(
 
     if max_spaces >= 0 && spaces_i64 > max_spaces {
         let severity = config.get_effective_severity(code, Severity::Warning);
-        let loc = Location::new(1, 1, start_offset);
-        let span = Span::new(loc, loc);
-
         return Some(
             DiagnosticBuilder::new(
                 code,
@@ -100,7 +95,7 @@ pub fn check_spaces_after_opening(
                 format!(
                     "too many spaces inside {collection_name} (expected at most {max_spaces}, found {spaces})"
                 ),
-                span,
+                opening_span,
             )
             .build(source),
         );
@@ -133,6 +128,7 @@ pub fn check_spaces_before_closing(
     code: &str,
     config: &LintConfig,
     collection_name: &str,
+    closing_span: Span,
 ) -> Option<Diagnostic> {
     if start_offset >= end_offset || end_offset > source.len() {
         return None;
@@ -150,9 +146,6 @@ pub fn check_spaces_before_closing(
 
     if min_spaces >= 0 && spaces_i64 < min_spaces {
         let severity = config.get_effective_severity(code, Severity::Warning);
-        let loc = Location::new(1, 1, end_offset);
-        let span = Span::new(loc, loc);
-
         return Some(
             DiagnosticBuilder::new(
                 code,
@@ -160,7 +153,7 @@ pub fn check_spaces_before_closing(
                 format!(
                     "too few spaces inside {collection_name} (expected at least {min_spaces}, found {spaces})"
                 ),
-                span,
+                closing_span,
             )
             .build(source),
         );
@@ -168,9 +161,6 @@ pub fn check_spaces_before_closing(
 
     if max_spaces >= 0 && spaces_i64 > max_spaces {
         let severity = config.get_effective_severity(code, Severity::Warning);
-        let loc = Location::new(1, 1, end_offset);
-        let span = Span::new(loc, loc);
-
         return Some(
             DiagnosticBuilder::new(
                 code,
@@ -178,7 +168,7 @@ pub fn check_spaces_before_closing(
                 format!(
                     "too many spaces inside {collection_name} (expected at most {max_spaces}, found {spaces})"
                 ),
-                span,
+                closing_span,
             )
             .build(source),
         );
@@ -202,31 +192,40 @@ mod tests {
 
     #[test]
     fn test_check_spaces_after_opening() {
+        use crate::{Location, Span};
+        let dummy_span = Span::new(Location::new(1, 1, 0), Location::new(1, 2, 1));
         let source = "{ key: value}";
         let config = LintConfig::default();
 
         // Should pass with 1 space
-        let result = check_spaces_after_opening(source, 1, 13, 0, 1, "test", &config, "braces");
+        let result =
+            check_spaces_after_opening(source, 1, 13, 0, 1, "test", &config, "braces", dummy_span);
         assert!(result.is_none());
 
         // Should fail with too many spaces
         let source2 = "{  key: value}";
-        let result2 = check_spaces_after_opening(source2, 1, 14, 0, 1, "test", &config, "braces");
+        let result2 =
+            check_spaces_after_opening(source2, 1, 14, 0, 1, "test", &config, "braces", dummy_span);
         assert!(result2.is_some());
     }
 
     #[test]
     fn test_check_spaces_before_closing() {
+        use crate::{Location, Span};
+        let dummy_span = Span::new(Location::new(1, 13, 12), Location::new(1, 14, 13));
         let source = "{key: value }";
         let config = LintConfig::default();
 
         // Should pass with 1 space
-        let result = check_spaces_before_closing(source, 1, 12, 0, 1, "test", &config, "braces");
+        let result =
+            check_spaces_before_closing(source, 1, 12, 0, 1, "test", &config, "braces", dummy_span);
         assert!(result.is_none());
 
         // Should fail with too many spaces
         let source2 = "{key: value  }";
-        let result2 = check_spaces_before_closing(source2, 1, 13, 0, 1, "test", &config, "braces");
+        let result2 = check_spaces_before_closing(
+            source2, 1, 13, 0, 1, "test", &config, "braces", dummy_span,
+        );
         assert!(result2.is_some());
     }
 }

--- a/crates/fast-yaml-linter/src/tokenizer.rs
+++ b/crates/fast-yaml-linter/src/tokenizer.rs
@@ -113,6 +113,19 @@ impl<'a> FlowTokenizer<'a> {
                             continue;
                         }
 
+                        // Skip braces/brackets that appear inside block-context plain scalars
+                        // (e.g. template expressions like `${{ var }}`).
+                        if matches!(
+                            token_type,
+                            TokenType::BraceOpen
+                                | TokenType::BraceClose
+                                | TokenType::BracketOpen
+                                | TokenType::BracketClose
+                        ) && Self::is_in_block_plain_scalar_at(line, col)
+                        {
+                            continue;
+                        }
+
                         let offset = line_start_offset + col;
                         let start = Location::new(line_num, col + 1, offset);
                         let end = Location::new(line_num, col + 2, offset + 1);
@@ -191,6 +204,127 @@ impl<'a> FlowTokenizer<'a> {
 
         // Already sorted by scan order (left to right, top to bottom)
         tokens
+    }
+
+    /// Checks if a position is inside a block-context plain scalar.
+    ///
+    /// A plain scalar starts when the first non-whitespace character after a value
+    /// separator (`: ` or `, `) is not a flow indicator (`{`, `[`, `"`, `'`).
+    /// In block context (outside any flow collection), such a plain scalar
+    /// continues to the end of the line, so any `{` or `[` inside it must not
+    /// be treated as a YAML flow collection delimiter.
+    ///
+    /// This prevents false positives on template expressions like `${{ var }}`
+    /// that appear as plain scalar values.
+    fn is_in_block_plain_scalar_at(line: &str, col: usize) -> bool {
+        let chars: Vec<char> = line.chars().collect();
+        if col >= chars.len() {
+            return false;
+        }
+
+        let mut i = 0usize;
+        let mut in_double = false;
+        let mut in_single = false;
+        let mut escape_next = false;
+        let mut flow_depth: usize = 0;
+        let mut at_value_start = false;
+        let mut in_plain_scalar = false;
+
+        while i < col {
+            let ch = chars[i];
+
+            if escape_next {
+                escape_next = false;
+                i += 1;
+                continue;
+            }
+
+            if in_double {
+                if ch == '\\' {
+                    escape_next = true;
+                } else if ch == '"' {
+                    in_double = false;
+                }
+                i += 1;
+                continue;
+            }
+
+            if in_single {
+                if ch == '\'' {
+                    in_single = false;
+                }
+                i += 1;
+                continue;
+            }
+
+            if in_plain_scalar {
+                // Block-context plain scalar ends at flow terminators only when nested
+                if flow_depth > 0 {
+                    match ch {
+                        ',' => {
+                            in_plain_scalar = false;
+                            at_value_start = true;
+                        }
+                        '}' | ']' => {
+                            in_plain_scalar = false;
+                            flow_depth = flow_depth.saturating_sub(1);
+                        }
+                        _ => {}
+                    }
+                }
+                // In block context (flow_depth == 0) plain scalar runs to EOL — nothing ends it
+                i += 1;
+                continue;
+            }
+
+            if at_value_start {
+                match ch {
+                    ' ' | '\t' => {}
+                    '"' => {
+                        in_double = true;
+                        at_value_start = false;
+                    }
+                    '\'' => {
+                        in_single = true;
+                        at_value_start = false;
+                    }
+                    '{' | '[' => {
+                        flow_depth += 1;
+                        at_value_start = false;
+                    }
+                    '#' => break,
+                    _ => {
+                        at_value_start = false;
+                        if flow_depth == 0 {
+                            // Block-context plain scalar — everything until EOL is scalar
+                            in_plain_scalar = true;
+                        }
+                        // Flow-context plain scalars cannot contain `{`/`[`, so we do not
+                        // set in_plain_scalar; any `{` encountered later will be treated
+                        // as a nested flow collection (or invalid YAML).
+                    }
+                }
+            } else {
+                match ch {
+                    '"' => in_double = true,
+                    '\'' => in_single = true,
+                    '{' | '[' => flow_depth += 1,
+                    '}' | ']' => flow_depth = flow_depth.saturating_sub(1),
+                    ':' if i + 1 < chars.len() && (chars[i + 1] == ' ' || chars[i + 1] == '\t') => {
+                        at_value_start = true;
+                        i += 2; // consume `: `
+                        continue;
+                    }
+                    ',' if flow_depth > 0 => at_value_start = true,
+                    '#' => break,
+                    _ => {}
+                }
+            }
+
+            i += 1;
+        }
+
+        in_plain_scalar
     }
 
     /// Checks if a position is inside a quoted string.


### PR DESCRIPTION
## Summary

- **#102**: `braces`/`brackets` diagnostics always reported `input:1:1` and appeared to fire twice per occurrence. Root cause: `flow_common.rs` hardcoded `Location::new(1, 1, offset)` for all diagnostic spans. Fix: `check_spaces_after_opening` and `check_spaces_before_closing` now accept the relevant token span and use it directly.

- **#103**: `braces`/`brackets` rules fired on template expressions like `${{ github.ref }}` and Jinja2 `{{ var }}` inside plain scalar values, producing 79 warnings on a 300-line GitHub Actions file. Root cause: the `FlowTokenizer` only skipped characters inside quoted strings, not inside plain scalars. Fix: added `is_in_block_plain_scalar_at` — a forward-scan state machine that tracks block-context plain scalar boundaries — and call it in `find_all` for brace/bracket tokens.

## Test plan

- `test_braces_correct_location` — verifies no diagnostic has offset 0 (was 1:1)
- `test_braces_no_duplicate_diagnostics` — verifies exactly 2 diagnostics at different offsets for `{ a: 1 }`
- `test_braces_no_false_positive_on_template_expression` — `key: ${{ github.ref }}` produces zero warnings
- `test_braces_no_false_positive_jinja2` — `"{{ variable }}"` produces zero warnings
- All 940 existing tests continue to pass