### PR TITLE
fix(cli): remove duplicate DuplicateKeysRule registration in fy lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CLI**: `fy lint` no longer reports each `duplicate-key` diagnostic twice. `Linter::with_config` already registers all default rules via `with_default_rules()`; the redundant manual `add_rule` calls in `lint.rs` have been removed. (#111)
 - **Linter**: `braces`/`brackets` rules no longer fire on template expressions (Jinja2, GitHub Actions `${{ }}`) inside plain scalar values. Previously the rules scanned raw source text and matched `{`/`[` inside string values, causing false-positive spam on workflow files. The tokenizer now tracks block-context plain scalars and skips flow-syntax characters inside them. (#103)
 - **Linter**: `braces`/`brackets` rules now report diagnostics at the correct source location (the `{`/`[` or `}`/`]` token) instead of always reporting line 1, column 1. (#102)
 - **Linter**: `duplicate-key` rule now detects duplicate keys at all nesting levels, not only at the top-level mapping. Previously, duplicates inside nested mappings were silently ignored. (#96)

--- a/crates/fast-yaml-cli/src/commands/lint.rs
+++ b/crates/fast-yaml-cli/src/commands/lint.rs
@@ -43,18 +43,8 @@ impl LintCommand {
             .with_indent_size(self.config.formatter.indent() as usize)
             .with_allow_duplicate_keys(self.allow_duplicate_keys);
 
-        // Create linter with all rules
-        let mut linter = Linter::with_config(lint_config);
-
-        // Add all default rules
-        linter
-            .add_rule(Box::new(fast_yaml_linter::rules::DuplicateKeysRule))
-            .add_rule(Box::new(fast_yaml_linter::rules::LineLengthRule))
-            .add_rule(Box::new(fast_yaml_linter::rules::TrailingWhitespaceRule))
-            .add_rule(Box::new(fast_yaml_linter::rules::DocumentStartRule))
-            .add_rule(Box::new(fast_yaml_linter::rules::DocumentEndRule))
-            .add_rule(Box::new(fast_yaml_linter::rules::EmptyValuesRule))
-            .add_rule(Box::new(fast_yaml_linter::rules::NewLineAtEndOfFileRule));
+        // Create linter with all default rules (registered via with_config → with_default_rules)
+        let linter = Linter::with_config(lint_config);
 
         // Run linter
         let diagnostics = linter.lint(input.as_str()).context("Failed to lint YAML")?;


### PR DESCRIPTION
## Summary

- Removes redundant `add_rule` calls in `crates/fast-yaml-cli/src/commands/lint.rs`
- `Linter::with_config` already registers all default rules via `RuleRegistry::with_default_rules()`, so manually adding them again caused each rule to run twice
- This manifested as every `duplicate-key` diagnostic appearing twice in `fy lint` output

## Test plan

- [ ] Existing test `test_lint_duplicate_keys_reported_by_default` confirms duplicate keys still produce `LintErrors`
- [ ] All 940 tests pass: `cargo nextest run --workspace --exclude fast-yaml --exclude fast-yaml-nodejs`
- [ ] Clippy clean: `cargo clippy --workspace --all-targets --all-features --exclude fast-yaml --exclude fast-yaml-nodejs -- -D warnings`

Closes #111