### PR TITLE
feat(cli): add --config flag and auto-discovery for fy lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CLI**: `fy lint` now supports a `--config <path>` flag to load rule configuration from a YAML file. Auto-discovery walks up from the current working directory looking for `.fast-yaml.yaml` or `.fast-yaml.yml` (up to 20 directory levels). Use `--no-config` to disable auto-discovery. (#123)
+- **CLI**: `--max-line-length`, `--indent-size`, and `--allow-duplicate-keys` flags on `fy lint` now use `Option<T>` so they only override config file values when explicitly provided; defaults are no longer silently applied over config file settings.
+- **Linter**: `ConfigFile` and `ConfigFileError` types in `fast-yaml-linter` for loading and merging `.fast-yaml.yaml` config files into `LintConfig`. Unknown rule names emit a warning to stderr.
+
 ## [0.5.3] - 2026-03-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "criterion",
  "fast-yaml-core",
@@ -406,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-cli"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -434,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bumpalo",
  "criterion",
@@ -448,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-linter"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "fast-yaml-core",
  "indoc",
@@ -456,12 +462,14 @@ dependencies = [
  "saphyr-parser",
  "serde",
  "serde_json",
+ "serde_norway",
+ "tempfile",
  "thiserror",
 ]
 
 [[package]]
 name = "fast-yaml-nodejs"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "fast-yaml-core",
  "fast-yaml-linter",
@@ -476,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-parallel"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "criterion",
  "fast-yaml-core",
@@ -662,12 +670,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -696,6 +710,16 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1235,6 +1259,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,6 +1343,19 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
 ]
 
 [[package]]
@@ -1426,6 +1469,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ saphyr = { version = "0.0.6" }
 saphyr-parser = { version = "0.0.6" }
 serde = { version = "1.0" }
 serde_json = { version = "1.0" }
+serde_norway = { version = "0.9" }
 thiserror = { version = "2.0" }
 
 # External dependencies - dev/test

--- a/crates/fast-yaml-cli/src/cli.rs
+++ b/crates/fast-yaml-cli/src/cli.rs
@@ -112,21 +112,29 @@ pub enum Command {
         /// Input file (default: stdin)
         file: Option<PathBuf>,
 
-        /// Maximum line length
-        #[arg(long, default_value = "120")]
-        max_line_length: usize,
+        /// Path to config file (default: auto-discover .fast-yaml.yaml)
+        #[arg(long, value_name = "FILE", conflicts_with = "no_config")]
+        config: Option<PathBuf>,
 
-        /// Indentation size
-        #[arg(long, default_value = "2")]
-        indent_size: usize,
+        /// Disable config file auto-discovery
+        #[arg(long, conflicts_with = "config")]
+        no_config: bool,
+
+        /// Maximum line length (overrides config file)
+        #[arg(long)]
+        max_line_length: Option<usize>,
+
+        /// Indentation size (overrides config file)
+        #[arg(long)]
+        indent_size: Option<usize>,
 
         /// Lint output format
         #[arg(long, value_enum, default_value = "text")]
         format: LintFormat,
 
-        /// Allow duplicate keys (opt-in, suppresses duplicate key errors)
-        #[arg(long)]
-        allow_duplicate_keys: bool,
+        /// Allow duplicate keys — overrides config file (opt-in, suppresses duplicate key errors)
+        #[arg(long, num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set)]
+        allow_duplicate_keys: Option<bool>,
     },
 }
 

--- a/crates/fast-yaml-cli/src/commands/lint.rs
+++ b/crates/fast-yaml-cli/src/commands/lint.rs
@@ -1,32 +1,94 @@
 use anyhow::{Context, Result};
-use fast_yaml_linter::{Formatter, JsonFormatter, LintConfig, Linter, Severity, TextFormatter};
+use fast_yaml_linter::{
+    ConfigFile, Formatter, JsonFormatter, LintConfig, Linter, Severity, TextFormatter,
+};
+use std::path::PathBuf;
 
 use crate::cli::LintFormat;
 use crate::config::CommonConfig;
 use crate::error::ExitCode;
 use crate::io::InputSource;
 
+/// CLI arguments for the lint command, separated from `CommonConfig`.
+pub struct LintArgs {
+    /// Explicit config file path (from `--config`).
+    pub config_path: Option<PathBuf>,
+    /// Whether to disable config file auto-discovery (`--no-config`).
+    pub no_config: bool,
+    /// Maximum line length override (from `--max-line-length`).
+    pub max_line_length: Option<usize>,
+    /// Indentation size override (from `--indent-size`).
+    pub indent_size: Option<usize>,
+    /// Lint output format.
+    pub format: LintFormat,
+    /// Allow duplicate keys override (from `--allow-duplicate-keys`).
+    pub allow_duplicate_keys: Option<bool>,
+}
+
 /// Lint command implementation
 pub struct LintCommand {
     config: CommonConfig,
-    max_line_length: usize,
+    lint_config: LintConfig,
     format: LintFormat,
-    allow_duplicate_keys: bool,
 }
 
 impl LintCommand {
-    pub const fn new(
-        config: CommonConfig,
-        max_line_length: usize,
-        format: LintFormat,
-        allow_duplicate_keys: bool,
-    ) -> Self {
-        Self {
+    /// Build the lint command, loading config file and applying CLI overrides.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if an explicit `--config` path cannot be read or parsed.
+    pub fn build(config: CommonConfig, args: LintArgs, input: &InputSource) -> Result<Self> {
+        let file_lint_config = Self::load_lint_config(args.config_path, args.no_config, input)?;
+        let lint_config = ConfigFile::merge_cli_overrides(
+            file_lint_config,
+            args.max_line_length,
+            args.indent_size,
+            args.allow_duplicate_keys,
+        );
+        Ok(Self {
             config,
-            max_line_length,
-            format,
-            allow_duplicate_keys,
+            lint_config,
+            format: args.format,
+        })
+    }
+
+    /// Load `LintConfig` from config file (explicit path, auto-discovered, or default).
+    fn load_lint_config(
+        config_path: Option<PathBuf>,
+        no_config: bool,
+        input: &InputSource,
+    ) -> Result<LintConfig> {
+        if no_config {
+            return Ok(LintConfig::default());
         }
+
+        if let Some(path) = config_path {
+            // Explicit --config: hard error if missing or invalid
+            let cfg = ConfigFile::load(&path)
+                .with_context(|| format!("failed to load config file '{}'", path.display()))?;
+            cfg.warn_unknown_rules();
+            return Ok(cfg.into_lint_config());
+        }
+
+        // Auto-discovery: start from CWD (matches yamllint behavior)
+        let start_dir = std::env::current_dir().unwrap_or_else(|_| {
+            input
+                .file_path()
+                .and_then(|p| p.parent().map(std::path::Path::to_owned))
+                .unwrap_or_else(|| PathBuf::from("."))
+        });
+
+        if let Some(discovered) = ConfigFile::discover(&start_dir) {
+            eprintln!("using config file: {}", discovered.display());
+            let cfg = ConfigFile::load(&discovered).with_context(|| {
+                format!("failed to load config file '{}'", discovered.display())
+            })?;
+            cfg.warn_unknown_rules();
+            return Ok(cfg.into_lint_config());
+        }
+
+        Ok(LintConfig::default())
     }
 
     /// Execute lint command
@@ -37,19 +99,17 @@ impl LintCommand {
     pub fn execute(&self, input: &InputSource) -> Result<ExitCode> {
         let start_time = std::time::Instant::now();
 
-        // Configure linter using formatter indent from config
-        let lint_config = LintConfig::new()
-            .with_max_line_length(Some(self.max_line_length))
-            .with_indent_size(self.config.formatter.indent() as usize)
-            .with_allow_duplicate_keys(self.allow_duplicate_keys);
+        // Apply indent from CommonConfig formatter only when linter config is at default
+        let effective_indent = self.config.formatter.indent() as usize;
+        let lint_config = if self.lint_config.indent_size == 2 && effective_indent != 2 {
+            self.lint_config.clone().with_indent_size(effective_indent)
+        } else {
+            self.lint_config.clone()
+        };
 
-        // Create linter with all default rules (registered via with_config → with_default_rules)
         let linter = Linter::with_config(lint_config);
-
-        // Run linter
         let diagnostics = linter.lint(input.as_str()).context("Failed to lint YAML")?;
 
-        // Filter diagnostics based on quiet mode (errors only)
         let filtered_diagnostics: Vec<_> = if self.config.output.is_quiet() {
             diagnostics
                 .into_iter()
@@ -59,7 +119,6 @@ impl LintCommand {
             diagnostics
         };
 
-        // Format output
         let output = match self.format {
             LintFormat::Text => {
                 let mut formatter = TextFormatter::new();
@@ -72,10 +131,8 @@ impl LintCommand {
             }
         };
 
-        // Print output
         print!("{output}");
 
-        // Print verbose info
         if self.config.output.is_verbose() && !matches!(self.format, LintFormat::Json) {
             let elapsed = start_time.elapsed();
             if let Some(path) = input.file_path() {
@@ -84,7 +141,6 @@ impl LintCommand {
             eprintln!("Lint time: {:.2}ms", elapsed.as_secs_f64() * 1000.0);
         }
 
-        // Determine exit code
         let has_errors = filtered_diagnostics
             .iter()
             .any(|d| d.severity == Severity::Error);
@@ -102,6 +158,7 @@ mod tests {
     use super::*;
     use crate::config::{FormatterConfig, OutputConfig};
     use crate::io::input::InputOrigin;
+    use std::io::Write;
 
     fn create_test_config(quiet: bool, verbose: bool, use_color: bool, indent: u8) -> CommonConfig {
         CommonConfig::new()
@@ -114,109 +171,239 @@ mod tests {
             .with_formatter(FormatterConfig::new().with_indent(indent))
     }
 
+    fn stdin_input(content: &str) -> InputSource {
+        InputSource {
+            content: content.to_string(),
+            origin: InputOrigin::Stdin,
+        }
+    }
+
+    fn build_no_config(
+        config: CommonConfig,
+        max_line_length: Option<usize>,
+        format: LintFormat,
+        allow_duplicate_keys: Option<bool>,
+        input: &InputSource,
+    ) -> LintCommand {
+        LintCommand::build(
+            config,
+            LintArgs {
+                config_path: None,
+                no_config: true,
+                max_line_length,
+                indent_size: None,
+                format,
+                allow_duplicate_keys,
+            },
+            input,
+        )
+        .unwrap()
+    }
+
     #[test]
     fn test_lint_valid_yaml() {
-        let input = InputSource {
-            content: "name: test\nvalue: 123".to_string(),
-            origin: InputOrigin::Stdin,
-        };
-
+        let input = stdin_input("name: test\nvalue: 123");
         let config = create_test_config(true, false, false, 2);
-        let cmd = LintCommand::new(config, 120, LintFormat::Text, false);
+        let cmd = build_no_config(config, Some(120), LintFormat::Text, None, &input);
         let result = cmd.execute(&input);
-
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), ExitCode::Success);
     }
 
     #[test]
     fn test_lint_with_warnings() {
-        let input = InputSource {
-            content: "name: this is a very very very very very very very very very very very very very very very very very very long line that exceeds the maximum".to_string(),
-            origin: InputOrigin::Stdin,
-        };
-
+        let long = "name: this is a very very very very very very very very very very very very very very very very very very long line that exceeds the maximum";
+        let input = stdin_input(long);
         let config = create_test_config(true, false, false, 2);
-        let cmd = LintCommand::new(config, 80, LintFormat::Text, false);
+        let cmd = build_no_config(config, Some(80), LintFormat::Text, None, &input);
         let result = cmd.execute(&input);
-
-        // Should succeed (warnings don't cause failure)
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), ExitCode::Success);
     }
 
     #[test]
     fn test_lint_invalid_yaml() {
-        let input = InputSource {
-            content: "invalid: [unclosed".to_string(),
-            origin: InputOrigin::Stdin,
-        };
-
+        let input = stdin_input("invalid: [unclosed");
         let config = create_test_config(true, false, false, 2);
-        let cmd = LintCommand::new(config, 120, LintFormat::Text, false);
+        let cmd = build_no_config(config, Some(120), LintFormat::Text, None, &input);
         let result = cmd.execute(&input);
-
-        // Should fail with parse error
         assert!(result.is_err());
     }
 
     #[test]
     fn test_lint_quiet_mode() {
-        let input = InputSource {
-            content: "name: test".to_string(),
-            origin: InputOrigin::Stdin,
-        };
-
+        let input = stdin_input("name: test");
         let config = create_test_config(true, false, false, 2);
-        let cmd = LintCommand::new(config, 120, LintFormat::Text, false);
+        let cmd = build_no_config(config, Some(120), LintFormat::Text, None, &input);
         let result = cmd.execute(&input);
-
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), ExitCode::Success);
     }
 
     #[test]
     fn test_lint_json_format() {
-        let input = InputSource {
-            content: "name: test\nvalue: 123".to_string(),
-            origin: InputOrigin::Stdin,
-        };
-
+        let input = stdin_input("name: test\nvalue: 123");
         let config = create_test_config(false, false, false, 2);
-        let cmd = LintCommand::new(config, 120, LintFormat::Json, false);
+        let cmd = build_no_config(config, Some(120), LintFormat::Json, None, &input);
         let result = cmd.execute(&input);
-
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), ExitCode::Success);
     }
 
     #[test]
     fn test_lint_duplicate_keys_reported_by_default() {
-        let input = InputSource {
-            content: "key: value1\nkey: value2\nother: data".to_string(),
-            origin: InputOrigin::Stdin,
-        };
-
+        let input = stdin_input("key: value1\nkey: value2\nother: data");
         let config = create_test_config(false, false, false, 2);
-        let cmd = LintCommand::new(config, 120, LintFormat::Text, false);
+        let cmd = build_no_config(config, Some(120), LintFormat::Text, None, &input);
         let result = cmd.execute(&input);
-
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), ExitCode::LintErrors);
     }
 
     #[test]
     fn test_lint_duplicate_keys_allowed_when_flag_set() {
-        let input = InputSource {
-            content: "key: value1\nkey: value2\nother: data".to_string(),
-            origin: InputOrigin::Stdin,
-        };
-
+        let input = stdin_input("key: value1\nkey: value2\nother: data");
         let config = create_test_config(false, false, false, 2);
-        let cmd = LintCommand::new(config, 120, LintFormat::Text, true);
+        let cmd = build_no_config(config, Some(120), LintFormat::Text, Some(true), &input);
         let result = cmd.execute(&input);
-
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), ExitCode::Success);
+    }
+
+    #[test]
+    fn test_config_file_overrides_defaults() {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "rules:\n  key-ordering:\n    enabled: false").unwrap();
+        let input = stdin_input("b: 1\na: 2");
+        let config = create_test_config(false, false, false, 2);
+        let cmd = LintCommand::build(
+            config,
+            LintArgs {
+                config_path: Some(f.path().to_owned()),
+                no_config: false,
+                max_line_length: None,
+                indent_size: None,
+                format: LintFormat::Text,
+                allow_duplicate_keys: None,
+            },
+            &input,
+        )
+        .unwrap();
+        let result = cmd.execute(&input);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_explicit_config_missing_file_returns_error() {
+        let input = stdin_input("name: test");
+        let config = create_test_config(false, false, false, 2);
+        let result = LintCommand::build(
+            config,
+            LintArgs {
+                config_path: Some(PathBuf::from("/nonexistent/.fast-yaml.yaml")),
+                no_config: false,
+                max_line_length: None,
+                indent_size: None,
+                format: LintFormat::Text,
+                allow_duplicate_keys: None,
+            },
+            &input,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_config_file_line_length_max_is_loaded() {
+        // Regression: config file line-length.max must set LintConfig::max_line_length,
+        // not just rule_configs, so LineLengthRule::check actually uses it.
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "rules:\n  line-length:\n    max: 50").unwrap();
+        let input = stdin_input("name: test");
+        let config = create_test_config(false, false, false, 2);
+        let cmd = LintCommand::build(
+            config,
+            LintArgs {
+                config_path: Some(f.path().to_owned()),
+                no_config: false,
+                max_line_length: None,
+                indent_size: None,
+                format: LintFormat::Text,
+                allow_duplicate_keys: None,
+            },
+            &input,
+        )
+        .unwrap();
+        assert_eq!(cmd.lint_config.max_line_length, Some(50));
+    }
+
+    #[test]
+    fn test_config_file_line_length_triggers_diagnostic() {
+        // End-to-end: a line longer than config-specified max must produce a diagnostic.
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "rules:\n  line-length:\n    max: 50").unwrap();
+        let long_line = "name: a-sixty-character-line-that-exceeds-fifty-chars-limit!!";
+        let input = stdin_input(long_line);
+        let config = create_test_config(true, false, false, 2);
+        let cmd = LintCommand::build(
+            config,
+            LintArgs {
+                config_path: Some(f.path().to_owned()),
+                no_config: false,
+                max_line_length: None,
+                indent_size: None,
+                format: LintFormat::Json,
+                allow_duplicate_keys: None,
+            },
+            &input,
+        )
+        .unwrap();
+        let result = cmd.execute(&input);
+        // Warnings don't cause LintErrors exit code (only errors do), but must not fail
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_cli_overrides_config_file_max_line_length() {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "rules:\n  line-length:\n    max: 50").unwrap();
+        let input = stdin_input("name: test");
+        let config = create_test_config(false, false, false, 2);
+        let cmd = LintCommand::build(
+            config,
+            LintArgs {
+                config_path: Some(f.path().to_owned()),
+                no_config: false,
+                max_line_length: Some(200),
+                indent_size: None,
+                format: LintFormat::Text,
+                allow_duplicate_keys: None,
+            },
+            &input,
+        )
+        .unwrap();
+        // CLI value wins over config file value
+        assert_eq!(cmd.lint_config.max_line_length, Some(200));
+    }
+
+    #[test]
+    fn test_allow_duplicate_keys_none_does_not_override() {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "rules: {{}}").unwrap();
+        let input = stdin_input("key: 1\nkey: 2");
+        let config = create_test_config(false, false, false, 2);
+        let cmd = LintCommand::build(
+            config,
+            LintArgs {
+                config_path: Some(f.path().to_owned()),
+                no_config: false,
+                max_line_length: None,
+                indent_size: None,
+                format: LintFormat::Text,
+                allow_duplicate_keys: None,
+            },
+            &input,
+        )
+        .unwrap();
+        assert!(!cmd.lint_config.allow_duplicate_keys);
     }
 }

--- a/crates/fast-yaml-cli/src/main.rs
+++ b/crates/fast-yaml-cli/src/main.rs
@@ -173,21 +173,23 @@ fn run() -> Result<ExitCode> {
         #[cfg(feature = "linter")]
         Some(Command::Lint {
             file,
+            config: config_path,
+            no_config,
             max_line_length,
             indent_size,
             format,
             allow_duplicate_keys,
         }) => {
             let input = InputSource::from_args(file)?;
-            let lint_config = common_config
-                .clone()
-                .with_formatter(config::FormatterConfig::new().with_indent(indent_size as u8));
-            let cmd = commands::lint::LintCommand::new(
-                lint_config,
+            let args = commands::lint::LintArgs {
+                config_path,
+                no_config,
                 max_line_length,
+                indent_size,
                 format,
                 allow_duplicate_keys,
-            );
+            };
+            let cmd = commands::lint::LintCommand::build(common_config.clone(), args, &input)?;
             cmd.execute(&input)?
         }
         None => {

--- a/crates/fast-yaml-linter/Cargo.toml
+++ b/crates/fast-yaml-linter/Cargo.toml
@@ -14,17 +14,19 @@ categories = ["development-tools", "parsing"]
 fast-yaml-core = { workspace = true }
 is-terminal = { workspace = true }
 saphyr-parser = { workspace = true }
-serde = { workspace = true, optional = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
+serde_norway = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
 indoc = { workspace = true }
+tempfile = { workspace = true }
 
 [features]
 default = []
-json-output = ["dep:serde", "dep:serde_json"]
-sarif-output = ["dep:serde", "dep:serde_json"]
+json-output = ["dep:serde_json"]
+sarif-output = ["dep:serde_json"]
 all-formats = ["json-output", "sarif-output"]
 
 [lints]

--- a/crates/fast-yaml-linter/src/config/config_file.rs
+++ b/crates/fast-yaml-linter/src/config/config_file.rs
@@ -1,0 +1,420 @@
+//! Config file loading, discovery, and merging into `LintConfig`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::Severity;
+use crate::config::{RuleConfig, RuleOption};
+use crate::linter::LintConfig;
+
+/// All known rule codes. Used to validate rule names from config files.
+const KNOWN_RULE_CODES: &[&str] = &[
+    "duplicate-key",
+    "invalid-anchor",
+    "undefined-alias",
+    "indentation",
+    "line-length",
+    "trailing-whitespace",
+    "document-start",
+    "document-end",
+    "empty-values",
+    "new-line-at-end-of-file",
+    "braces",
+    "brackets",
+    "colons",
+    "commas",
+    "hyphens",
+    "comments",
+    "comments-indentation",
+    "empty-lines",
+    "new-lines",
+    "octal-values",
+    "truthy",
+    "quoted-strings",
+    "key-ordering",
+    "float-values",
+];
+
+/// Depth limit for config file discovery walk-up.
+const MAX_DISCOVERY_DEPTH: usize = 20;
+
+/// Top-level structure of a `.fast-yaml.yaml` config file.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ConfigFile {
+    /// Map of rule code to per-rule configuration.
+    #[serde(default)]
+    pub rules: HashMap<String, ConfigFileRule>,
+}
+
+/// Per-rule configuration entry from the config file.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ConfigFileRule {
+    /// Whether this rule is enabled.
+    pub enabled: Option<bool>,
+    /// Override the rule's default severity.
+    pub severity: Option<ConfigFileSeverity>,
+    /// Rule-specific options.
+    #[serde(flatten)]
+    pub options: HashMap<String, ConfigFileValue>,
+}
+
+/// Severity value as parsed from the config file.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConfigFileSeverity {
+    /// Critical error severity.
+    Error,
+    /// Warning severity.
+    Warning,
+    /// Informational severity.
+    Info,
+    /// Hint severity.
+    Hint,
+}
+
+impl From<ConfigFileSeverity> for Severity {
+    fn from(s: ConfigFileSeverity) -> Self {
+        match s {
+            ConfigFileSeverity::Error => Self::Error,
+            ConfigFileSeverity::Warning => Self::Warning,
+            ConfigFileSeverity::Info => Self::Info,
+            ConfigFileSeverity::Hint => Self::Hint,
+        }
+    }
+}
+
+/// Untyped option value from a config file rule block.
+///
+/// Variant ordering matters for `serde(untagged)`: `Bool` must come before
+/// `Int` because YAML integers are not booleans, but serde tries variants in
+/// order and stops at first match.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum ConfigFileValue {
+    /// Boolean value (true/false).
+    Bool(bool),
+    /// Integer value.
+    Int(i64),
+    /// String value.
+    String(String),
+    /// List of strings.
+    StringList(Vec<String>),
+}
+
+/// Errors from config file loading.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigFileError {
+    /// I/O error reading config file.
+    #[error("failed to read config file '{path}': {source}")]
+    Io {
+        /// Path that failed.
+        path: PathBuf,
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// YAML parse error in config file.
+    #[error("failed to parse config file '{path}': {source}")]
+    Parse {
+        /// Path that failed.
+        path: PathBuf,
+        /// Underlying parse error.
+        source: serde_norway::Error,
+    },
+}
+
+impl ConfigFile {
+    /// Load and parse a config file from disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ConfigFileError` on I/O or parse failure.
+    pub fn load(path: &Path) -> Result<Self, ConfigFileError> {
+        let content = std::fs::read_to_string(path).map_err(|source| ConfigFileError::Io {
+            path: path.to_owned(),
+            source,
+        })?;
+        serde_norway::from_str(&content).map_err(|source| ConfigFileError::Parse {
+            path: path.to_owned(),
+            source,
+        })
+    }
+
+    /// Walk up the directory tree from `start_dir` looking for `.fast-yaml.yaml`
+    /// or `.fast-yaml.yml`. Returns the first found path, or `None` if not found.
+    ///
+    /// Uses iterative `parent()` instead of `canonicalize()` to avoid following
+    /// symlinks across filesystems. Depth is capped at `MAX_DISCOVERY_DEPTH`.
+    pub fn discover(start_dir: &Path) -> Option<PathBuf> {
+        let mut dir = start_dir.to_owned();
+        for _ in 0..MAX_DISCOVERY_DEPTH {
+            for name in [".fast-yaml.yaml", ".fast-yaml.yml"] {
+                let candidate = dir.join(name);
+                if candidate.is_file() {
+                    return Some(candidate);
+                }
+            }
+            if !dir.pop() {
+                return None;
+            }
+        }
+        None
+    }
+
+    /// Validate rule names against the known set. Emit warnings to stderr for
+    /// unknown names so users get feedback on typos.
+    pub fn warn_unknown_rules(&self) {
+        for name in self.rules.keys() {
+            if !KNOWN_RULE_CODES.contains(&name.as_str()) {
+                eprintln!("warning: unknown rule '{name}' in config file");
+            }
+        }
+    }
+
+    /// Convert into a `LintConfig`, applying all `rules:` entries.
+    #[must_use]
+    pub fn into_lint_config(self) -> LintConfig {
+        let mut config = LintConfig::default();
+
+        for (rule_name, rule_cfg) in self.rules {
+            if !KNOWN_RULE_CODES.contains(&rule_name.as_str()) {
+                continue; // already warned above
+            }
+
+            let enabled = rule_cfg.enabled.unwrap_or(true);
+            let mut rc = if enabled {
+                RuleConfig::new()
+            } else {
+                RuleConfig::disabled()
+            };
+
+            if let Some(sev) = rule_cfg.severity {
+                rc = rc.with_severity(sev.into());
+            }
+
+            for (key, val) in rule_cfg.options {
+                // Special case: line-length.max maps to the top-level LintConfig field because
+                // LineLengthRule reads config.max_line_length directly, not rule_configs.
+                if rule_name == "line-length"
+                    && key == "max"
+                    && let ConfigFileValue::Int(max) = &val
+                    && let Ok(max_usize) = usize::try_from(*max)
+                {
+                    config.max_line_length = Some(max_usize);
+                }
+                let opt = match val {
+                    ConfigFileValue::Bool(b) => RuleOption::Bool(b),
+                    ConfigFileValue::Int(i) => RuleOption::Int(i),
+                    ConfigFileValue::String(s) => RuleOption::String(s),
+                    ConfigFileValue::StringList(v) => RuleOption::StringList(v),
+                };
+                rc = rc.with_option(key, opt);
+            }
+
+            config = config.with_rule_config(rule_name, rc);
+        }
+
+        config
+    }
+
+    /// Apply CLI flag overrides on top of a config-derived `LintConfig`.
+    /// Only overrides fields where the CLI option was explicitly provided
+    /// (`Some(_)` values).
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)] // cannot be const: contains if-let with Option
+    pub fn merge_cli_overrides(
+        mut config: LintConfig,
+        max_line_length: Option<usize>,
+        indent_size: Option<usize>,
+        allow_duplicate_keys: Option<bool>,
+    ) -> LintConfig {
+        if let Some(v) = max_line_length {
+            config.max_line_length = Some(v);
+        }
+        if let Some(v) = indent_size {
+            config.indent_size = v;
+        }
+        if let Some(v) = allow_duplicate_keys {
+            config.allow_duplicate_keys = v;
+        }
+        config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_temp(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn test_load_valid_config() {
+        let f = write_temp(
+            "rules:\n  line-length:\n    enabled: true\n    max: 100\n  key-ordering:\n    enabled: false\n",
+        );
+        let cfg = ConfigFile::load(f.path()).unwrap();
+        assert!(cfg.rules.contains_key("line-length"));
+        assert_eq!(cfg.rules["line-length"].enabled, Some(true));
+        assert_eq!(cfg.rules["key-ordering"].enabled, Some(false));
+    }
+
+    #[test]
+    fn test_load_missing_file_returns_error() {
+        let result = ConfigFile::load(Path::new("/nonexistent/path/.fast-yaml.yaml"));
+        assert!(matches!(result, Err(ConfigFileError::Io { .. })));
+    }
+
+    #[test]
+    fn test_load_invalid_yaml_returns_parse_error() {
+        let f = write_temp("rules: [broken yaml: {");
+        let result = ConfigFile::load(f.path());
+        assert!(matches!(result, Err(ConfigFileError::Parse { .. })));
+    }
+
+    #[test]
+    fn test_into_lint_config_disables_rule() {
+        let f = write_temp("rules:\n  key-ordering:\n    enabled: false\n");
+        let cfg = ConfigFile::load(f.path()).unwrap();
+        let lint_config = cfg.into_lint_config();
+        assert!(!lint_config.is_rule_enabled("key-ordering"));
+    }
+
+    #[test]
+    fn test_into_lint_config_sets_options() {
+        let f = write_temp("rules:\n  line-length:\n    max: 100\n");
+        let cfg = ConfigFile::load(f.path()).unwrap();
+        let lint_config = cfg.into_lint_config();
+        let rc = lint_config.get_rule_config("line-length").unwrap();
+        assert_eq!(rc.options.get_usize("max"), Some(100));
+    }
+
+    #[test]
+    fn test_line_length_max_sets_top_level_field() {
+        // Regression: line-length.max from config file must propagate to LintConfig::max_line_length
+        // because LineLengthRule reads that field directly, not rule_configs.
+        let f = write_temp("rules:\n  line-length:\n    max: 50\n");
+        let cfg = ConfigFile::load(f.path()).unwrap();
+        let lint_config = cfg.into_lint_config();
+        assert_eq!(lint_config.max_line_length, Some(50));
+    }
+
+    #[test]
+    fn test_line_length_max_actually_affects_linting() {
+        use crate::Linter;
+        // A 60-character line should trigger a diagnostic when max=50 is set via config file.
+        let long_line = "name: a-sixty-character-line-that-exceeds-fifty-chars-limit!!";
+        assert_eq!(long_line.len(), 61);
+
+        let f = write_temp("rules:\n  line-length:\n    max: 50\n");
+        let cfg = ConfigFile::load(f.path()).unwrap();
+        let lint_config = cfg.into_lint_config();
+
+        let linter = Linter::with_config(lint_config);
+        let diagnostics = linter.lint(long_line).unwrap();
+        assert!(
+            diagnostics.iter().any(|d| d.code.as_str() == "line-length"),
+            "expected line-length diagnostic for 61-char line with max=50"
+        );
+    }
+
+    #[test]
+    fn test_line_length_default_not_triggered_for_short_line() {
+        use crate::Linter;
+        // Without config, default max_line_length is Some(80). A 60-char line should not trigger.
+        let short_line = "name: this-line-is-about-sixty-characters-long-no-more-here";
+        assert!(short_line.len() < 80);
+
+        let f = write_temp("rules: {}");
+        let cfg = ConfigFile::load(f.path()).unwrap();
+        let lint_config = cfg.into_lint_config();
+
+        let linter = Linter::with_config(lint_config);
+        let diagnostics = linter.lint(short_line).unwrap();
+        assert!(
+            !diagnostics.iter().any(|d| d.code.as_str() == "line-length"),
+            "expected no line-length diagnostic for <80-char line with default config"
+        );
+    }
+
+    #[test]
+    fn test_merge_cli_overrides_takes_precedence() {
+        let base = LintConfig::default();
+        let result = ConfigFile::merge_cli_overrides(base, Some(200), Some(4), Some(true));
+        assert_eq!(result.max_line_length, Some(200));
+        assert_eq!(result.indent_size, 4);
+        assert!(result.allow_duplicate_keys);
+    }
+
+    #[test]
+    fn test_merge_cli_overrides_none_does_not_override() {
+        let base = LintConfig::new()
+            .with_max_line_length(Some(42))
+            .with_indent_size(3);
+        let result = ConfigFile::merge_cli_overrides(base, None, None, None);
+        assert_eq!(result.max_line_length, Some(42));
+        assert_eq!(result.indent_size, 3);
+    }
+
+    #[test]
+    fn test_discover_finds_config_in_same_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join(".fast-yaml.yaml");
+        std::fs::write(&config_path, "rules: {}").unwrap();
+
+        let found = ConfigFile::discover(dir.path());
+        assert_eq!(found, Some(config_path));
+    }
+
+    #[test]
+    fn test_discover_finds_config_in_parent() {
+        let parent = tempfile::tempdir().unwrap();
+        let child = parent.path().join("subdir");
+        std::fs::create_dir(&child).unwrap();
+        let config_path = parent.path().join(".fast-yaml.yaml");
+        std::fs::write(&config_path, "rules: {}").unwrap();
+
+        let found = ConfigFile::discover(&child);
+        assert_eq!(found, Some(config_path));
+    }
+
+    #[test]
+    fn test_discover_returns_none_when_not_found() {
+        let found = ConfigFile::discover(Path::new("/"));
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_warn_unknown_rules_does_not_panic() {
+        let f = write_temp("rules:\n  unknown-rule-xyz:\n    enabled: true\n");
+        let cfg = ConfigFile::load(f.path()).unwrap();
+        // Should not panic, warns to stderr
+        cfg.warn_unknown_rules();
+    }
+
+    #[test]
+    fn test_config_file_value_bool_ordering() {
+        let f = write_temp("rules:\n  truthy:\n    allow-bool-values: true\n");
+        let cfg = ConfigFile::load(f.path()).unwrap();
+        let rule = &cfg.rules["truthy"];
+        assert!(matches!(
+            rule.options.get("allow-bool-values"),
+            Some(ConfigFileValue::Bool(true))
+        ));
+    }
+
+    #[test]
+    fn test_config_file_severity_deserialization() {
+        let f = write_temp("rules:\n  line-length:\n    severity: warning\n");
+        let cfg = ConfigFile::load(f.path()).unwrap();
+        let rule = &cfg.rules["line-length"];
+        assert!(matches!(rule.severity, Some(ConfigFileSeverity::Warning)));
+    }
+}

--- a/crates/fast-yaml-linter/src/config/mod.rs
+++ b/crates/fast-yaml-linter/src/config/mod.rs
@@ -1,5 +1,7 @@
 //! Rule configuration types and builders.
 
+pub mod config_file;
 mod rule_config;
 
+pub use config_file::{ConfigFile, ConfigFileError};
 pub use rule_config::{RuleConfig, RuleOption, RuleOptions};

--- a/crates/fast-yaml-linter/src/lib.rs
+++ b/crates/fast-yaml-linter/src/lib.rs
@@ -39,6 +39,7 @@ pub mod rules;
 pub mod source;
 pub mod tokenizer;
 
+pub use config::{ConfigFile, ConfigFileError};
 pub use context::{LineMetadata, LintContext, SourceContext};
 pub use diagnostic::{
     ContextLine, Diagnostic, DiagnosticBuilder, DiagnosticCode, DiagnosticContext, Suggestion,


### PR DESCRIPTION
## Summary

- Add `--config <path>` flag to `fy lint` for loading per-project rule configuration from a YAML file
- Implement auto-discovery: walk up from CWD looking for `.fast-yaml.yaml` / `.fast-yaml.yml` (depth limit: 20)
- CLI flags override config file values; `--no-config` disables auto-discovery
- Unknown rule names in config emit a warning to stderr
- Fix silent ignore of `line-length.max` from config file (was stored in `rule_configs` but `LineLengthRule` reads `max_line_length` directly)

Config file format:
```yaml
rules:
  line-length:
    max: 100
  key-ordering:
    enabled: false
  quoted-strings:
    required: always
```

## Test plan

- [ ] `fy lint --config .fast-yaml.yaml file.yaml` applies config file rules
- [ ] Auto-discovery finds `.fast-yaml.yaml` walking up from CWD
- [ ] CLI `--max-line-length` overrides config file value
- [ ] `--no-config` disables auto-discovery
- [ ] Unknown rule name in config prints warning to stderr
- [ ] Missing explicit `--config` path returns hard error
- [ ] `line-length.max` from config file actually triggers diagnostics (regression for M1 bug)
- [ ] 977 tests pass, clippy clean, fmt clean

Closes #123