### PR TITLE
fix(linter): enabled: false in config file now correctly disables rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Python**: `safe_dump()` `indent` and `default_flow_style` parameters now take effect. Previously both were accepted but silently ignored. `indent=N` rescales block-style indentation to N spaces; `default_flow_style=True` renders all mappings and sequences in flow style (`{k: v}` / `[a, b]`). (#127)
 - fix(linter): `duplicate-key` rule reported 0-indexed column numbers in JSON output; saphyr `col()` is 0-indexed and now correctly converted to 1-indexed (#131)
 - fix(linter): `key-ordering` rule silently skipped nested mapping keys when the parent mapping had more than one top-level key; fixed by interleaving key location with value recursion (#130)
+- fix(linter): `enabled: false` in config file did not disable rules; `is_rule_disabled` now checks `rule_configs` in addition to the `disabled_rules` set (#133)
 
 ## [0.5.3] - 2026-03-25
 

--- a/crates/fast-yaml-linter/src/linter.rs
+++ b/crates/fast-yaml-linter/src/linter.rs
@@ -132,6 +132,7 @@ impl LintConfig {
     #[must_use]
     pub fn is_rule_disabled(&self, code: &str) -> bool {
         self.disabled_rules.contains(code)
+            || self.rule_configs.get(code).is_some_and(|rc| !rc.enabled)
     }
 
     /// Gets the configuration for a specific rule.
@@ -567,5 +568,25 @@ mod tests {
         let diagnostics = linter.lint(yaml).unwrap();
 
         assert!(!diagnostics.iter().any(|d| d.code.as_str() == "line-length"));
+    }
+
+    #[test]
+    fn test_linter_rule_config_disabled_suppresses_rule() {
+        // Regression test for #133: RuleConfig::disabled() via with_rule_config should
+        // suppress the rule, not just store it in rule_configs without effect.
+        let yaml = "very_long_line: this line is definitely longer than eighty characters and should trigger a warning";
+        let config = LintConfig::new()
+            .with_rule_config("line-length", crate::config::RuleConfig::disabled());
+        let linter = Linter::with_config(config);
+
+        let mut linter = linter;
+        linter.add_rule(Box::new(crate::rules::LineLengthRule));
+
+        let diagnostics = linter.lint(yaml).unwrap();
+
+        assert!(
+            !diagnostics.iter().any(|d| d.code.as_str() == "line-length"),
+            "rule disabled via RuleConfig::disabled() should not produce diagnostics"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `is_rule_disabled()` only checked the `disabled_rules` HashSet, ignoring entries in `rule_configs` where `enabled=false`
- Extended the check to consult `rule_configs` so that `RuleConfig::disabled()` set via `with_rule_config()` (i.e. from a config file) actually suppresses the rule
- Added regression test `test_linter_rule_config_disabled_suppresses_rule`

Fixes #133

## Test plan

- [ ] `cargo nextest run -p fast-yaml-linter` — all tests pass including new regression test
- [ ] Create `.fast-yaml.yaml` with `rules: key-ordering: enabled: false` and verify `fy lint` no longer reports key-ordering diagnostics