### PR TITLE
fix(linter): detect signed floats without leading numeral (-.5, +.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(linter): `duplicate-key` rule reported 0-indexed column numbers in JSON output; saphyr `col()` is 0-indexed and now correctly converted to 1-indexed (#131)
 - fix(linter): `key-ordering` rule silently skipped nested mapping keys when the parent mapping had more than one top-level key; fixed by interleaving key location with value recursion (#130)
 - fix(linter): `enabled: false` in config file did not disable rules; `is_rule_disabled` now checks `rule_configs` in addition to the `disabled_rules` set (#133)
+- fix(linter): `float-values` rule now detects signed floats without a leading numeral (`-.5`, `+.5`) in addition to the previously handled bare `.5` case (#138)
 
 ## [0.5.3] - 2026-03-25
 

--- a/crates/fast-yaml-linter/src/rules/float_values.rs
+++ b/crates/fast-yaml-linter/src/rules/float_values.rs
@@ -124,10 +124,11 @@ impl super::LintRule for FloatValuesRule {
                 let value_lower = value_token.to_lowercase();
 
                 // Check for missing numeral before decimal point
-                if require_numeral_before_decimal && value_token.starts_with('.') {
-                    // Check if it's a valid float starting with '.'
-                    if value_token.len() > 1
-                        && value_token[1..].chars().next().unwrap().is_ascii_digit()
+                let bare = value_token.trim_start_matches(['-', '+']);
+                if require_numeral_before_decimal && bare.starts_with('.') {
+                    // Check if it's a valid float starting with '.' (e.g. .5, -.5, +.5)
+                    if bare.len() > 1
+                        && bare[1..].chars().next().is_some_and(|c| c.is_ascii_digit())
                     {
                         let value_start =
                             line[part_offset..].find(value_token).unwrap_or(0) + part_offset;
@@ -423,6 +424,23 @@ mod tests {
         let context = LintContext::new(yaml);
         let diagnostics = rule.check(&context, &value, &config);
         assert!(!diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_float_values_signed_missing_numeral() {
+        let yaml = "bad1: .5\nbad2: -.5\nbad3: +.5\ngood: 0.5";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = FloatValuesRule;
+        let config = LintConfig::default();
+
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &config);
+        assert_eq!(
+            diagnostics.len(),
+            3,
+            "expected diagnostics for .5, -.5, +.5"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Strip leading `[-+]` sign from the value token before checking `starts_with('.')` in the `float-values` rule
- `-.5` and `+.5` are now flagged alongside bare `.5` when `require-numeral-before-decimal` is enabled

## Test plan

- Added `test_float_values_signed_missing_numeral` that asserts exactly 3 diagnostics for `.5`, `-.5`, `+.5` and no diagnostic for `0.5`
- All 379 existing linter unit tests pass

Closes #138