### PR TITLE
fix(linter): strip CRLF carriage return before trailing-whitespace check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(linter): `key-ordering` rule silently skipped nested mapping keys when the parent mapping had more than one top-level key; fixed by interleaving key location with value recursion (#130)
 - fix(linter): `enabled: false` in config file did not disable rules; `is_rule_disabled` now checks `rule_configs` in addition to the `disabled_rules` set (#133)
 - fix(linter): `float-values` rule now detects signed floats without a leading numeral (`-.5`, `+.5`) in addition to the previously handled bare `.5` case (#138)
+- fix(linter): `trailing-whitespace` rule no longer emits false-positive hints on CRLF files; the `\r` from a `\r\n` line ending is now stripped before the whitespace check (#141)
 
 ## [0.5.3] - 2026-03-25
 

--- a/crates/fast-yaml-linter/src/rules/trailing_whitespace.rs
+++ b/crates/fast-yaml-linter/src/rules/trailing_whitespace.rs
@@ -38,6 +38,10 @@ impl super::LintRule for TrailingWhitespaceRule {
 
         for line_num in 1..=ctx.line_count() {
             if let Some(line) = ctx.get_line(line_num) {
+                // Strip carriage return from CRLF line endings before checking
+                // trailing whitespace — \r is part of the line ending, not user
+                // content, so it must not trigger a trailing-whitespace warning.
+                let line = line.trim_end_matches('\r');
                 // Check for trailing whitespace (excluding final newline)
                 let trimmed = line.trim_end();
 
@@ -148,6 +152,38 @@ mod tests {
 
         // Empty lines should not trigger
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_crlf_line_endings_no_false_positive() {
+        // CRLF files: \r should not be reported as trailing whitespace.
+        let yaml = "key: value\r\nother: val\r\n";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = TrailingWhitespaceRule;
+        let config = LintConfig::default();
+        let lint_context = LintContext::new(yaml);
+        let diagnostics = rule.check(&lint_context, &value, &config);
+
+        assert!(
+            diagnostics.is_empty(),
+            "CRLF line endings must not trigger trailing-whitespace: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn test_crlf_with_real_trailing_whitespace() {
+        // CRLF file that also has genuine trailing spaces — must still report.
+        let yaml = "key: value  \r\nother: val\r\n";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = TrailingWhitespaceRule;
+        let config = LintConfig::default();
+        let lint_context = LintContext::new(yaml);
+        let diagnostics = rule.check(&lint_context, &value, &config);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `trailing-whitespace` rule emitted false-positive hints on every line of Windows-format (CRLF) YAML files because `SourceContext::get_line()` returns raw line slices that include the `\r` byte
- Strip trailing `\r` before the whitespace check so `\r\n` line endings are treated the same as `\n`
- Genuine trailing spaces/tabs before the `\r` are still reported correctly

Fixes #141.

## Test plan

- [ ] `test_crlf_line_endings_no_false_positive` — pure CRLF file produces no `trailing-whitespace` diagnostics
- [ ] `test_crlf_with_real_trailing_whitespace` — CRLF file with genuine trailing spaces still reports one diagnostic
- [ ] All 1011 existing tests pass (`cargo nextest run`)