### PR TITLE
fix(linter): check all documents in multi-doc YAML streams (#142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(linter): `enabled: false` in config file did not disable rules; `is_rule_disabled` now checks `rule_configs` in addition to the `disabled_rules` set (#133)
 - fix(linter): `float-values` rule now detects signed floats without a leading numeral (`-.5`, `+.5`) in addition to the previously handled bare `.5` case (#138)
 - fix(linter): `trailing-whitespace` rule no longer emits false-positive hints on CRLF files; the `\r` from a `\r\n` line ending is now stripped before the whitespace check (#141)
+- fix(linter): value-based rules (`key-ordering`, `empty-values`) now check all documents in a multi-document YAML stream; previously only the first document was checked (#142)
 
 ## [0.5.3] - 2026-03-25
 

--- a/crates/fast-yaml-linter/src/linter.rs
+++ b/crates/fast-yaml-linter/src/linter.rs
@@ -1,7 +1,7 @@
 //! Main linter engine and configuration.
 
 use crate::{Diagnostic, LintContext, Severity, config::RuleConfig, rules::RuleRegistry};
-use fast_yaml_core::{Parser, Value};
+use fast_yaml_core::{Parser, ScalarOwned, Value};
 use std::collections::{HashMap, HashSet};
 
 /// Configuration for the linter.
@@ -364,12 +364,27 @@ impl Linter {
     /// let diagnostics = linter.lint(yaml).unwrap();
     /// ```
     pub fn lint(&self, source: &str) -> Result<Vec<Diagnostic>, LintError> {
-        let value_opt = Parser::parse_str(source)?;
+        let docs = Parser::parse_all(source)?;
+        let context = LintContext::new(source);
+        let mut diagnostics = Vec::new();
 
-        value_opt.map_or_else(
-            || Ok(Vec::new()),
-            |value| Ok(self.lint_value(source, &value)),
-        )
+        for rule in self.registry.rules() {
+            if self.config.is_rule_disabled(rule.code()) {
+                continue;
+            }
+
+            if rule.needs_value() {
+                for doc in &docs {
+                    diagnostics.extend(rule.check(&context, doc, &self.config));
+                }
+            } else {
+                let dummy = Value::Value(ScalarOwned::Null);
+                diagnostics.extend(rule.check(&context, &dummy, &self.config));
+            }
+        }
+
+        diagnostics.sort_by(|a, b| a.span.start.cmp(&b.span.start));
+        Ok(diagnostics)
     }
 
     /// Lints a pre-parsed Value (avoids double parsing).
@@ -568,6 +583,80 @@ mod tests {
         let diagnostics = linter.lint(yaml).unwrap();
 
         assert!(!diagnostics.iter().any(|d| d.code.as_str() == "line-length"));
+    }
+
+    #[test]
+    fn test_multidoc_key_ordering_all_documents() {
+        // Regression test for #142: key-ordering must fire in ALL documents, not just the first.
+        let yaml = "---\nb: 1\na: 2\n---\nd: 1\nc: 2\n";
+        let config = LintConfig::new().with_rule_config(
+            crate::DiagnosticCode::KEY_ORDERING,
+            crate::config::RuleConfig::new(),
+        );
+        let linter = Linter::with_all_rules_and_config(config);
+        let diagnostics = linter.lint(yaml).unwrap();
+
+        let ordering_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code.as_str() == crate::DiagnosticCode::KEY_ORDERING)
+            .collect();
+
+        assert!(
+            ordering_diags.len() >= 2,
+            "key-ordering should fire in both documents, got {} diagnostics: {:?}",
+            ordering_diags.len(),
+            ordering_diags
+        );
+    }
+
+    #[test]
+    fn test_multidoc_empty_values_all_documents() {
+        // Regression test for #142: empty-values must fire in ALL documents, not just the first.
+        let yaml = "---\nfoo:\n---\nbar:\n";
+        let linter = Linter::with_all_rules();
+        let diagnostics = linter.lint(yaml).unwrap();
+
+        let empty_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code.as_str() == crate::DiagnosticCode::EMPTY_VALUES)
+            .collect();
+
+        assert!(
+            empty_diags.len() >= 2,
+            "empty-values should fire in both documents, got {} diagnostics: {:?}",
+            empty_diags.len(),
+            empty_diags
+        );
+    }
+
+    #[test]
+    fn test_single_doc_key_ordering_no_regression() {
+        // Verify single-doc YAML with correct key order produces no key-ordering diagnostic.
+        let yaml = "a: 1\nb: 2\nc: 3\n";
+        let linter = Linter::with_all_rules();
+        let diagnostics = linter.lint(yaml).unwrap();
+
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.code.as_str() == crate::DiagnosticCode::KEY_ORDERING),
+            "correctly ordered single-doc should produce no key-ordering diagnostics"
+        );
+    }
+
+    #[test]
+    fn test_single_doc_empty_values_no_regression() {
+        // Verify single-doc YAML without empty values produces no empty-values diagnostic.
+        let yaml = "foo: bar\nbaz: qux\n";
+        let linter = Linter::with_all_rules();
+        let diagnostics = linter.lint(yaml).unwrap();
+
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.code.as_str() == crate::DiagnosticCode::EMPTY_VALUES),
+            "single-doc without empty values should produce no empty-values diagnostics"
+        );
     }
 
     #[test]

--- a/crates/fast-yaml-linter/src/rules/empty_values.rs
+++ b/crates/fast-yaml-linter/src/rules/empty_values.rs
@@ -42,6 +42,10 @@ impl super::LintRule for EmptyValuesRule {
         "Forbids keys with implicit null values (missing explicit 'null' or '~')"
     }
 
+    fn needs_value(&self) -> bool {
+        true
+    }
+
     fn default_severity(&self) -> Severity {
         Severity::Warning
     }

--- a/crates/fast-yaml-linter/src/rules/key_ordering.rs
+++ b/crates/fast-yaml-linter/src/rules/key_ordering.rs
@@ -44,6 +44,10 @@ impl super::LintRule for KeyOrderingRule {
         "Checks if keys in mappings are alphabetically ordered"
     }
 
+    fn needs_value(&self) -> bool {
+        true
+    }
+
     fn default_severity(&self) -> Severity {
         Severity::Info
     }

--- a/crates/fast-yaml-linter/src/rules/mod.rs
+++ b/crates/fast-yaml-linter/src/rules/mod.rs
@@ -105,6 +105,15 @@ pub trait LintRule: Send + Sync {
     /// Default severity level.
     fn default_severity(&self) -> Severity;
 
+    /// Returns true if this rule requires walking the parsed Value tree.
+    ///
+    /// Rules that return `true` are run once per document in a multi-document
+    /// stream. Rules that return `false` (the default) scan source text and are
+    /// run once for the full input.
+    fn needs_value(&self) -> bool {
+        false
+    }
+
     /// Checks the source and returns diagnostics.
     ///
     /// # Parameters


### PR DESCRIPTION
## Summary

- Add `needs_value() -> bool` to `LintRule` trait (default `false`) to distinguish rules that require a parsed `Value` from those that scan raw source
- `key-ordering` and `empty-values` override `needs_value()` to `true`
- `Linter::lint()` now calls `Parser::parse_all()` and runs value-based rules once per document; text-based rules run once on the full source unchanged

## Test plan

- [ ] `test_multidoc_key_ordering_all_documents` — key-ordering fires on both docs in a multi-doc stream
- [ ] `test_multidoc_empty_values_all_documents` — empty-values fires on both docs in a multi-doc stream
- [ ] `test_single_doc_key_ordering_no_regression` — single-doc with ordered keys produces no diagnostic
- [ ] `test_single_doc_empty_values_no_regression` — single-doc without empty values produces no diagnostic
- [ ] Full CI: 1013 tests pass, clippy clean, fmt clean, deny clean, docs clean

Closes #142