### PR TITLE
fix(python): raise ValueError on complex YAML mapping keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - fix(linter): implement indentation rule — detect wrong indent size and mixed tabs/spaces (#139)
+- **Python**: `safe_load()` now raises `ValueError` with a clear message when YAML contains complex keys (sequences or mappings as mapping keys) instead of a confusing `TypeError` (#144)
 - fix(nodejs): `new Linter()` with no args now uses default rules instead of an empty registry (fixes #124)
 - fix(python): `Linter()` with no args now uses default rules instead of an empty registry (fixes #135)
 - **Python**: `safe_dump()` `indent` and `default_flow_style` parameters now take effect. Previously both were accepted but silently ignored. `indent=N` rescales block-style indentation to N spaces; `default_flow_style=True` renders all mappings and sequences in flow style (`{k: v}` / `[a, b]`). (#127)

--- a/python/src/conversion.rs
+++ b/python/src/conversion.rs
@@ -63,6 +63,11 @@ pub fn value_to_python(py: Python<'_>, value: &Value) -> PyResult<Py<PyAny>> {
             let pairs: Vec<(Py<PyAny>, Py<PyAny>)> = map
                 .iter()
                 .map(|(k, v)| {
+                    if matches!(k, Value::Sequence(_) | Value::Mapping(_)) {
+                        return Err(PyValueError::new_err(
+                            "YAML complex keys (sequences or mappings as keys) are not supported as Python dict keys",
+                        ));
+                    }
                     let py_key = value_to_python(py, k)?;
                     let py_value = value_to_python(py, v)?;
                     Ok((py_key, py_value))

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -340,6 +340,11 @@ fn yaml_to_python(py: Python<'_>, yaml: &YamlOwned) -> PyResult<Py<PyAny>> {
             let pairs: Vec<(Py<PyAny>, Py<PyAny>)> = map
                 .iter()
                 .map(|(k, v)| {
+                    if matches!(k, YamlOwned::Sequence(_) | YamlOwned::Mapping(_)) {
+                        return Err(PyValueError::new_err(
+                            "YAML complex keys (sequences or mappings as keys) are not supported as Python dict keys",
+                        ));
+                    }
                     let py_key = yaml_to_python(py, k)?;
                     let py_value = yaml_to_python(py, v)?;
                     Ok((py_key, py_value))

--- a/python/tests/test_loaders.py
+++ b/python/tests/test_loaders.py
@@ -264,3 +264,34 @@ class TestInputValidation:
         large_yaml = "key: " + ("x" * (100 * 1024 * 1024))
         with pytest.raises(ValueError, match="exceeds maximum"):
             fast_yaml.load_all(large_yaml)
+
+    def test_safe_load_sequence_key_raises_value_error(self):
+        """safe_load() raises ValueError on sequence complex key."""
+        yaml_str = "? [a, b]\n: val"
+        with pytest.raises(ValueError, match="complex keys"):
+            fast_yaml.safe_load(yaml_str)
+
+    def test_safe_load_mapping_key_raises_value_error(self):
+        """safe_load() raises ValueError on mapping complex key."""
+        yaml_str = "? {k: v}\n: val"
+        with pytest.raises(ValueError, match="complex keys"):
+            fast_yaml.safe_load(yaml_str)
+
+    def test_safe_load_complex_key_not_type_error(self):
+        """safe_load() raises ValueError (not TypeError) on complex key."""
+        yaml_str = "? [a, b]\n: val"
+        with pytest.raises(ValueError):
+            fast_yaml.safe_load(yaml_str)
+        # ensure it's not a TypeError
+        try:
+            fast_yaml.safe_load(yaml_str)
+        except TypeError:
+            pytest.fail("safe_load raised TypeError instead of ValueError for complex key")
+        except ValueError:
+            pass
+
+    def test_safe_load_scalar_keys_work(self):
+        """safe_load() works normally for scalar keys (regression guard)."""
+        yaml_str = "key: value\nnumber: 42\nbool: true"
+        result = fast_yaml.safe_load(yaml_str)
+        assert result == {"key": "value", "number": 42, "bool": True}


### PR DESCRIPTION
## Summary

- `safe_load()` raised `TypeError: cannot use 'list' as a dict key` on YAML with complex (non-scalar) mapping keys, which are valid per YAML 1.2.2 spec (section 7.5, example 2.11)
- Added early guard in `yaml_to_python` (lib.rs) and `value_to_python` (conversion.rs): when a mapping key is a sequence or mapping, raises `ValueError` with a clear message explaining the Python limitation
- Added 4 pytest tests covering sequence key, mapping key, error type guard, and scalar key regression

## Test plan

- [ ] `safe_load('? [a, b]\n: val')` raises `ValueError` matching "complex keys"
- [ ] `safe_load('? {k: v}\n: val')` raises `ValueError` matching "complex keys"
- [ ] Confirmed `TypeError` is NOT raised
- [ ] Normal scalar keys still work
- [ ] 398 Python tests pass, 1009 Rust tests pass

Closes #144