### PR TITLE
fix(linter): eliminate O(n²) compute_offset in quoted-strings rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix(linter): replace O(n²) `compute_offset` in `quoted-strings` rule with O(1) `SourceContext::get_line_offset` lookup (#147)
 - fix(linter): implement indentation rule — detect wrong indent size and mixed tabs/spaces (#139)
 - **Python**: `safe_load()` now raises `ValueError` with a clear message when YAML contains complex keys (sequences or mappings as mapping keys) instead of a confusing `TypeError` (#144)
 - fix(nodejs): `new Linter()` with no args now uses default rules instead of an empty registry (fixes #124)


### PR DESCRIPTION
## Summary

- Replace `QuotedStringsRule::compute_offset()` (O(n) per scalar scan from source start) with `SourceContext::get_line_offset()` (O(1) lookup via pre-built `line_starts` index)
- Remove the now-unused `compute_offset` private method
- Overall linting complexity for the `quoted-strings` rule drops from O(n²) to O(n)

## Test plan

- [ ] All 1020 existing tests pass (`cargo nextest run`)
- [ ] Clippy clean with `-D warnings`
- [ ] `cargo +nightly fmt --check` passes
- [ ] Manual: generate 10 000-key YAML file and verify lint time drops from ~1.1s to <20ms

Fixes #147