### PR TITLE
fix(linter): correct key-ordering line numbers in multi-doc streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(linter): value-based rules (`key-ordering`, `empty-values`) now check all documents in a multi-document YAML stream; previously only the first document was checked (#142)
 - fix(linter): `rules.indentation.indent-size` in config file is now forwarded to `LintConfig::indent_size`; previously the option was stored in `rule_configs` but never applied, so the default 2-space indent was always used (#149)
 - fix(linter): `quoted-strings` rule always reported column 1 and wrong byte offset; `make_span` now uses the actual 0-indexed saphyr column converted to 1-indexed, and offset is computed via `SourceContext::get_line_offset` (O(1)) instead of a per-call O(n) scan (#153)
+- fix(linter): `key-ordering` rule reported wrong line numbers for documents after the first in multi-document streams; the forward-scan cursor now starts at each document's actual start line instead of always starting at line 1 (#156)
 
 ## [0.5.3] - 2026-03-25
 

--- a/crates/fast-yaml-linter/src/context.rs
+++ b/crates/fast-yaml-linter/src/context.rs
@@ -442,6 +442,8 @@ pub struct LintContext<'a> {
     comments: OnceLock<Vec<Comment>>,
     lines: OnceLock<Vec<&'a str>>,
     line_metadata: OnceLock<Vec<LineMetadata>>,
+    /// 1-based line number where the current document starts within `source`.
+    doc_start_line: usize,
 }
 
 impl<'a> LintContext<'a> {
@@ -466,7 +468,29 @@ impl<'a> LintContext<'a> {
             comments: OnceLock::new(),
             lines: OnceLock::new(),
             line_metadata: OnceLock::new(),
+            doc_start_line: 1,
         }
+    }
+
+    /// Returns a copy of this context with `doc_start_line` set to `line`.
+    ///
+    /// Used by the linter when processing individual documents within a
+    /// multi-document stream so that rules which scan forward from a cursor
+    /// can start at the correct document boundary.
+    #[must_use]
+    pub const fn with_doc_start_line(mut self, line: usize) -> Self {
+        self.doc_start_line = line;
+        self
+    }
+
+    /// Returns the 1-based line number where the current document begins.
+    ///
+    /// For a single-document source this is always 1. For multi-document
+    /// streams the linter sets this to the document's actual start line so
+    /// that rules can initialize their forward-scan cursors correctly.
+    #[must_use]
+    pub const fn doc_start_line(&self) -> usize {
+        self.doc_start_line
     }
 
     /// Returns the original source text.

--- a/crates/fast-yaml-linter/src/linter.rs
+++ b/crates/fast-yaml-linter/src/linter.rs
@@ -365,6 +365,7 @@ impl Linter {
     /// ```
     pub fn lint(&self, source: &str) -> Result<Vec<Diagnostic>, LintError> {
         let docs = Parser::parse_all(source)?;
+        let doc_start_lines = compute_doc_start_lines(source, docs.len());
         let context = LintContext::new(source);
         let mut diagnostics = Vec::new();
 
@@ -374,8 +375,10 @@ impl Linter {
             }
 
             if rule.needs_value() {
-                for doc in &docs {
-                    diagnostics.extend(rule.check(&context, doc, &self.config));
+                for (idx, doc) in docs.iter().enumerate() {
+                    let start_line = doc_start_lines.get(idx).copied().unwrap_or(1);
+                    let doc_context = LintContext::new(source).with_doc_start_line(start_line);
+                    diagnostics.extend(rule.check(&doc_context, doc, &self.config));
                 }
             } else {
                 let dummy = Value::Value(ScalarOwned::Null);
@@ -467,6 +470,29 @@ pub enum LintError {
     /// Failed to parse YAML.
     #[error("failed to parse YAML: {0}")]
     ParseError(#[from] fast_yaml_core::ParseError),
+}
+
+/// Returns a `Vec` where `result[i]` is the 1-based line number at which
+/// document `i` begins in `source`.
+///
+/// Document boundaries are detected by scanning for lines that consist solely
+/// of `---` (the YAML directive-end marker). The first document always starts
+/// at line 1. Each `---` line introduces the *next* document, which begins on
+/// the following line.
+fn compute_doc_start_lines(source: &str, doc_count: usize) -> Vec<usize> {
+    let mut starts = Vec::with_capacity(doc_count);
+    starts.push(1usize);
+
+    for (idx, line) in source.lines().enumerate() {
+        if line.trim_end_matches('\r') == "---" {
+            starts.push(idx + 2); // line after `---` (1-based)
+            if starts.len() == doc_count {
+                break;
+            }
+        }
+    }
+
+    starts
 }
 
 #[cfg(test)]

--- a/crates/fast-yaml-linter/src/rules/key_ordering.rs
+++ b/crates/fast-yaml-linter/src/rules/key_ordering.rs
@@ -61,7 +61,7 @@ impl super::LintRule for KeyOrderingRule {
             .unwrap_or(true);
 
         let mut diagnostics = Vec::new();
-        let mut cursor = 1usize;
+        let mut cursor = context.doc_start_line();
 
         check_value(
             value,
@@ -395,6 +395,42 @@ mod tests {
             "expected 2 diagnostics, got {}: {:?}",
             diagnostics.len(),
             diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    /// Regression test for #156: key-ordering must report correct line numbers
+    /// for each document in a multi-doc stream. The second document's cursor
+    /// must start at its own first line, not at line 1.
+    #[test]
+    fn test_key_ordering_multi_doc_correct_line_numbers() {
+        let yaml = "z: 1\na: 2\n---\nz: 3\na: 4\n";
+        let values = fast_yaml_core::Parser::parse_all(yaml).unwrap();
+
+        let rule = KeyOrderingRule;
+        let config = LintConfig::default();
+
+        // doc 0 starts at line 1, doc 1 starts at line 4 (line after `---`)
+        let doc_start_lines = [1usize, 4usize];
+        let mut all_diagnostics: Vec<Diagnostic> = Vec::new();
+        for (idx, value) in values.iter().enumerate() {
+            let context = LintContext::new(yaml).with_doc_start_line(doc_start_lines[idx]);
+            all_diagnostics.extend(rule.check(&context, value, &config));
+        }
+
+        assert_eq!(all_diagnostics.len(), 2, "expected exactly 2 diagnostics");
+
+        // First diagnostic: `a` at line 2 (second line of doc 1)
+        assert_eq!(
+            all_diagnostics[0].span.start.line, 2,
+            "first diagnostic should point to line 2, got {}",
+            all_diagnostics[0].span.start.line
+        );
+
+        // Second diagnostic: `a` at line 5 (fifth line of the full stream)
+        assert_eq!(
+            all_diagnostics[1].span.start.line, 5,
+            "second diagnostic should point to line 5, got {}",
+            all_diagnostics[1].span.start.line
         );
     }
 


### PR DESCRIPTION
## Summary

- `key-ordering` cursor now starts at each document's actual start line instead of always line 1
- `LintContext` gains a `doc_start_line` field (default 1, backward-compatible)
- `Linter::lint()` computes per-document start lines by scanning for `---` separators
- Adds regression test verifying correct line numbers for second and later documents

## Root cause

The forward-scan cursor in `check_value()` was initialized to `1` on every `rule.check()` call. For multi-doc streams the linter calls the rule once per document, so the cursor for doc 2+ always latched onto the first document's key positions.

## Test plan

- [x] New test `test_key_ordering_multi_doc_correct_line_numbers` asserts line 2 and line 5 for the two `a:` keys in a two-document stream
- [x] All existing key-ordering tests pass (14 total)
- [x] Full test suite: 1030 tests pass
- [x] `cargo clippy -- -D warnings`: clean
- [x] `cargo +nightly fmt --check`: clean

Closes #156