### PR TITLE
fix(linter): comments false positive in block scalars, float-values signed suggestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix(linter): `comments` rule no longer emits false-positive diagnostics for `#` characters inside block scalars (`|` and `>`); block scalar context is now tracked by indentation level (#160)
+- fix(linter): `float-values` suggestion for signed leading-dot floats now correctly inserts `0` after the sign character (`-.5` → `-0.5`, `+.5` → `+0.5`) instead of prepending `0` before the sign (#159)
+
 - fix(linter): replace O(n²) `compute_offset` in `quoted-strings` rule with O(1) `SourceContext::get_line_offset` lookup (#147)
 - **Python**: `safe_dump_all()` now accepts `indent`, `width`, `explicit_start`, and `default_flow_style` parameters, matching the `safe_dump()` API. (#151)
 - fix(linter): implement indentation rule — detect wrong indent size and mixed tabs/spaces (#139)

--- a/crates/fast-yaml-linter/src/comment_parser.rs
+++ b/crates/fast-yaml-linter/src/comment_parser.rs
@@ -94,9 +94,30 @@ impl<'a> CommentParser<'a> {
         let mut in_string = false;
         let mut string_delimiter = b'"';
         let mut escape_next = false;
+        // block_scalar_indent: Some(n) means we're inside a block scalar where
+        // any line with indentation > n belongs to the scalar content.
+        let mut block_scalar_indent: Option<usize> = None;
 
         for (line_idx, line) in self.source.lines().enumerate() {
             let line_start_offset = self.context.get_line_offset(line_idx + 1);
+
+            // Determine indentation of current line (number of leading spaces)
+            let indent = line.len() - line.trim_start().len();
+
+            // Check if we need to exit block scalar state
+            if let Some(scalar_indent) = block_scalar_indent {
+                if line.trim().is_empty() {
+                    // blank lines are still inside the block scalar, skip
+                    continue;
+                }
+                if indent <= scalar_indent {
+                    // We've returned to or before the block scalar entry level
+                    block_scalar_indent = None;
+                } else {
+                    // Still inside block scalar content — skip this line
+                    continue;
+                }
+            }
 
             for (col_idx, ch) in line.char_indices() {
                 let offset = line_start_offset + col_idx;
@@ -151,6 +172,21 @@ impl<'a> CommentParser<'a> {
 
                     // Rest of line is comment, skip to next line
                     break;
+                }
+            }
+
+            // Detect block scalar markers: a line ending with `|` or `>` (optionally
+            // followed by chomping indicators `+`/`-` and/or an indentation hint digit)
+            // outside of a quoted string signals that subsequent indented lines are
+            // scalar content and must not be scanned for `#` comments.
+            let trimmed_line = line.trim_end();
+            let after_value = trimmed_line.trim_start_matches(|c: char| !matches!(c, '|' | '>'));
+            if !after_value.is_empty() {
+                let rest = after_value.trim_start_matches(['|', '>']);
+                let rest = rest.trim_start_matches(['+', '-']);
+                let rest = rest.trim_start_matches(|c: char| c.is_ascii_digit());
+                if rest.is_empty() && after_value.starts_with(['|', '>']) {
+                    block_scalar_indent = Some(indent);
                 }
             }
 
@@ -361,11 +397,9 @@ mod tests {
         let context = SourceContext::new(yaml);
         let parser = CommentParser::new(yaml, &context);
 
-        // Parser should not detect these as comments (they're in block scalar)
-        // For now, our simple parser will detect them - this documents the limitation
+        // Lines inside the block scalar must not be treated as comments
         let comments = parser.find_all();
-        // Current implementation treats these as comments (acceptable for Phase 3)
-        assert_eq!(comments.len(), 2);
+        assert_eq!(comments.len(), 0);
     }
 
     #[test]

--- a/crates/fast-yaml-linter/src/rules/comments.rs
+++ b/crates/fast-yaml-linter/src/rules/comments.rs
@@ -297,6 +297,24 @@ mod tests {
     }
 
     #[test]
+    fn test_comments_shebang_in_block_scalar_no_false_positive() {
+        // Regression test for #160: '#' inside a '|' block scalar must not
+        // produce a comment diagnostic.
+        let yaml = "script: |\n  #!/bin/bash\n  echo hello\nkey: value";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = CommentsRule;
+        let config = LintConfig::default();
+
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &config);
+        assert!(
+            diagnostics.is_empty(),
+            "expected no diagnostics, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
     fn test_comments_in_string_ignored() {
         let yaml = r#"text: "not # a comment""#;
         let value = Parser::parse_str(yaml).unwrap().unwrap();

--- a/crates/fast-yaml-linter/src/rules/float_values.rs
+++ b/crates/fast-yaml-linter/src/rules/float_values.rs
@@ -142,12 +142,17 @@ impl super::LintRule for FloatValuesRule {
                             Location::new(line_num, 1, offset + value_token.len()),
                         );
 
+                        let suggestion = if value_token.starts_with(['-', '+']) {
+                            format!("{}0{}", &value_token[..1], &value_token[1..])
+                        } else {
+                            format!("0{value_token}")
+                        };
                         diagnostics.push(
                             DiagnosticBuilder::new(
                                 self.code(),
                                 severity,
                                 format!(
-                                    "float value '{value_token}' should have a numeral before the decimal point (e.g., '0{value_token}')"
+                                    "float value '{value_token}' should have a numeral before the decimal point (e.g., '{suggestion}')"
                                 ),
                                 span,
                             )
@@ -440,6 +445,29 @@ mod tests {
             diagnostics.len(),
             3,
             "expected diagnostics for .5, -.5, +.5"
+        );
+    }
+
+    #[test]
+    fn test_float_values_signed_suggestion() {
+        let yaml = "neg: -.5\npos: +.5";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = FloatValuesRule;
+        let config = LintConfig::default();
+
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &config);
+        assert_eq!(diagnostics.len(), 2, "expected diagnostics for -.5 and +.5");
+        assert!(
+            diagnostics[0].message.contains("-0.5"),
+            "suggestion for -.5 should be -0.5, got: {}",
+            diagnostics[0].message
+        );
+        assert!(
+            diagnostics[1].message.contains("+0.5"),
+            "suggestion for +.5 should be +0.5, got: {}",
+            diagnostics[1].message
         );
     }
 


### PR DESCRIPTION
## Summary

- **#160**: `comments` rule was scanning `#` characters inside block scalars (`|`, `>`) and producing false-positive diagnostics (e.g., `#!/bin/bash` in CI `run:` blocks). Fixed by tracking block scalar context in `CommentParser` via indentation level — lines indented deeper than the scalar marker are skipped.
- **#159**: `float-values` suggestion for signed leading-dot floats was incorrectly prepending `0` before the sign (`-.5` → `'0-.5'`). Fixed by inserting `0` after the sign character (`-.5` → `-0.5`, `+.5` → `+0.5`).

## Changes

- `crates/fast-yaml-linter/src/comment_parser.rs` — block scalar state tracking in `parse_comments()`
- `crates/fast-yaml-linter/src/rules/float_values.rs` — correct signed float suggestion
- `crates/fast-yaml-linter/src/rules/comments.rs` — regression test for #160
- `crates/fast-yaml-linter/src/rules/float_values.rs` — regression test for #159

## Test plan

- [ ] `cargo nextest run --workspace --exclude fast-yaml --exclude fast-yaml-nodejs` — 1032 tests pass
- [ ] `cargo clippy ... -D warnings` — clean
- [ ] `cargo +nightly fmt --check` — clean
- [ ] Regression: `#!/bin/bash` inside `|` block scalar produces 0 comments diagnostics
- [ ] Regression: `-.5` suggestion is `-0.5`, `+.5` suggestion is `+0.5`

Closes #160
Closes #159