### PR TITLE
fix(linter): correct hyphens rule false positives after multibyte chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix(linter): correct `hyphens` rule false positives on list items following non-ASCII (multibyte) characters by using byte-level indexing instead of `chars().nth(offset)` (#161)
 - fix(linter): `comments` rule no longer emits false-positive diagnostics for `#` characters inside block scalars (`|` and `>`); block scalar context is now tracked by indentation level (#160)
 - fix(linter): `float-values` suggestion for signed leading-dot floats now correctly inserts `0` after the sign character (`-.5` → `-0.5`, `+.5` → `+0.5`) instead of prepending `0` before the sign (#159)
-
 - fix(linter): replace O(n²) `compute_offset` in `quoted-strings` rule with O(1) `SourceContext::get_line_offset` lookup (#147)
 - **Python**: `safe_dump_all()` now accepts `indent`, `width`, `explicit_start`, and `default_flow_style` parameters, matching the `safe_dump()` API. (#151)
 - fix(linter): implement indentation rule — detect wrong indent size and mixed tabs/spaces (#139)

--- a/crates/fast-yaml-linter/src/rules/hyphens.rs
+++ b/crates/fast-yaml-linter/src/rules/hyphens.rs
@@ -105,14 +105,11 @@ fn check_spaces_after_hyphen(
     let mut spaces = 0;
     let mut offset = hyphen_offset + 1;
 
-    while offset < source.len() {
-        if let Some(ch) = source.chars().nth(offset) {
-            if ch == ' ' {
-                spaces += 1;
-                offset += 1;
-            } else {
-                break;
-            }
+    let bytes = source.as_bytes();
+    while offset < bytes.len() {
+        if bytes[offset] == b' ' {
+            spaces += 1;
+            offset += 1;
         } else {
             break;
         }
@@ -126,8 +123,8 @@ fn check_spaces_after_hyphen(
     let spaces_i64 = spaces as i64;
 
     // Require at least one space after hyphen (unless it's at end of line)
-    if spaces == 0 && offset < source.len() {
-        let next_char = source.chars().nth(offset);
+    if spaces == 0 && offset < bytes.len() {
+        let next_char = bytes.get(offset).copied().map(char::from);
         if let Some(ch) = next_char
             && ch != '\n'
             && ch != '\r'
@@ -318,6 +315,23 @@ mod tests {
         assert_eq!(
             diagnostics[0].span.start.line, 1,
             "first violation should be on line 1"
+        );
+    }
+
+    #[test]
+    fn test_hyphens_no_false_positive_after_multibyte_chars() {
+        // ✓ is 3 bytes but 1 char; byte offset and char index diverge after it
+        let yaml = "items:\n  - note: \"contains ✓ checkmark\"\n  - item1\n  - item2";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = HyphensRule;
+        let config = LintConfig::default();
+
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &config);
+        assert!(
+            diagnostics.is_empty(),
+            "valid list items after multibyte chars should not trigger hyphens rule: {diagnostics:?}"
         );
     }
 


### PR DESCRIPTION
Fixes #161.

## Summary

- Replace `source.chars().nth(offset)` with `source.as_bytes()[offset]` in the `hyphens` rule
- The `FlowTokenizer` provides byte offsets; `chars().nth()` treats them as character indices, causing divergence when multibyte UTF-8 characters (e.g. `✓`, emojis) appear before list items
- Adds regression test `test_hyphens_no_false_positive_after_multibyte_chars`

## Test plan

- [ ] `cargo nextest run -p fast-yaml-linter` — all 413 tests pass
- [ ] `cargo clippy ... -- -D warnings` — no warnings
- [ ] `cargo +nightly fmt --check` — no formatting changes