### PR TITLE
perf(linter): eliminate O(n²) SourceContext allocation in DiagnosticBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(linter): `rules.indentation.indent-size` in config file is now forwarded to `LintConfig::indent_size`; previously the option was stored in `rule_configs` but never applied, so the default 2-space indent was always used (#149)
 - fix(linter): `quoted-strings` rule always reported column 1 and wrong byte offset; `make_span` now uses the actual 0-indexed saphyr column converted to 1-indexed, and offset is computed via `SourceContext::get_line_offset` (O(1)) instead of a per-call O(n) scan (#153)
 - fix(linter): `key-ordering` rule reported wrong line numbers for documents after the first in multi-document streams; the forward-scan cursor now starts at each document's actual start line instead of always starting at line 1 (#156)
+- fix(linter): `DiagnosticBuilder::build` called `SourceContext::new` on every diagnostic, causing O(n²) work when many rules fired; added `build_with_context` method and updated all rule call sites to reuse the pre-built `SourceContext` from `LintContext` (#157)
 
 ## [0.5.3] - 2026-03-25
 

--- a/crates/fast-yaml-linter/src/diagnostic.rs
+++ b/crates/fast-yaml-linter/src/diagnostic.rs
@@ -328,9 +328,50 @@ impl DiagnosticBuilder {
         self
     }
 
+    /// Builds the diagnostic using a pre-built [`SourceContext`].
+    ///
+    /// Prefer this over [`build`](Self::build) when a `SourceContext` is already available
+    /// (e.g. from [`crate::LintContext::source_context`]) to avoid rebuilding the line index on
+    /// every diagnostic.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fast_yaml_linter::{DiagnosticBuilder, DiagnosticCode, LintContext, Severity, Location, Span};
+    ///
+    /// let source = "name: John\nage: 30";
+    /// let ctx = LintContext::new(source);
+    /// let span = Span::new(Location::new(1, 1, 0), Location::new(1, 4, 3));
+    ///
+    /// let diagnostic = DiagnosticBuilder::new(
+    ///     DiagnosticCode::LINE_LENGTH,
+    ///     Severity::Info,
+    ///     "example",
+    ///     span
+    /// ).build_with_context(ctx.source_context());
+    ///
+    /// assert!(diagnostic.context.is_some());
+    /// ```
+    #[must_use]
+    pub fn build_with_context(self, source_ctx: &SourceContext<'_>) -> Diagnostic {
+        let context = source_ctx.extract_context(self.span, 2);
+
+        Diagnostic {
+            code: self.code,
+            severity: self.severity,
+            message: self.message,
+            span: self.span,
+            context: Some(context),
+            suggestions: self.suggestions,
+        }
+    }
+
     /// Builds the diagnostic with source context.
     ///
     /// Extracts context lines from the source around the diagnostic span.
+    ///
+    /// Consider using [`build_with_context`](Self::build_with_context) instead when a
+    /// [`SourceContext`] is already available to avoid redundant line index construction.
     ///
     /// # Examples
     ///

--- a/crates/fast-yaml-linter/src/rules/braces.rs
+++ b/crates/fast-yaml-linter/src/rules/braces.rs
@@ -100,7 +100,7 @@ impl super::LintRule for BracesRule {
                             "flow mapping forbidden (forbid: all)",
                             token.span,
                         )
-                        .build(source),
+                        .build_with_context(source_context),
                     );
                 }
                 return diagnostics;
@@ -124,7 +124,7 @@ impl super::LintRule for BracesRule {
                                 "non-empty flow mapping forbidden (forbid: non-empty)",
                                 open.span,
                             )
-                            .build(source),
+                            .build_with_context(source_context),
                         );
                     }
                 }
@@ -148,6 +148,7 @@ impl super::LintRule for BracesRule {
                 // Check spaces after opening brace
                 if let Some(diag) = check_spaces_after_opening(
                     source,
+                    source_context,
                     open.span.end.offset,
                     close.span.start.offset,
                     min_spaces,
@@ -163,6 +164,7 @@ impl super::LintRule for BracesRule {
                 // Check spaces before closing brace
                 if let Some(diag) = check_spaces_before_closing(
                     source,
+                    source_context,
                     open.span.end.offset,
                     close.span.start.offset,
                     min_spaces,

--- a/crates/fast-yaml-linter/src/rules/brackets.rs
+++ b/crates/fast-yaml-linter/src/rules/brackets.rs
@@ -100,7 +100,7 @@ impl super::LintRule for BracketsRule {
                             "flow sequence forbidden (forbid: all)",
                             token.span,
                         )
-                        .build(source),
+                        .build_with_context(source_context),
                     );
                 }
                 return diagnostics;
@@ -124,7 +124,7 @@ impl super::LintRule for BracketsRule {
                                 "non-empty flow sequence forbidden (forbid: non-empty)",
                                 open.span,
                             )
-                            .build(source),
+                            .build_with_context(source_context),
                         );
                     }
                 }
@@ -148,6 +148,7 @@ impl super::LintRule for BracketsRule {
                 // Check spaces after opening bracket
                 if let Some(diag) = check_spaces_after_opening(
                     source,
+                    source_context,
                     open.span.end.offset,
                     close.span.start.offset,
                     min_spaces,
@@ -163,6 +164,7 @@ impl super::LintRule for BracketsRule {
                 // Check spaces before closing bracket
                 if let Some(diag) = check_spaces_before_closing(
                     source,
+                    source_context,
                     open.span.end.offset,
                     close.span.start.offset,
                     min_spaces,

--- a/crates/fast-yaml-linter/src/rules/colons.rs
+++ b/crates/fast-yaml-linter/src/rules/colons.rs
@@ -193,7 +193,7 @@ fn check_spaces_before_colon(
                 ),
                 span,
             )
-            .build(source),
+            .build_with_context(source_context),
         );
     }
 
@@ -248,7 +248,7 @@ fn check_spaces_after_colon(
                 ),
                 span,
             )
-            .build(source),
+            .build_with_context(source_context),
         );
     }
 

--- a/crates/fast-yaml-linter/src/rules/commas.rs
+++ b/crates/fast-yaml-linter/src/rules/commas.rs
@@ -151,7 +151,7 @@ fn check_spaces_before_comma(
                 ),
                 span,
             )
-            .build(source),
+            .build_with_context(source_context),
         );
     }
 
@@ -212,7 +212,7 @@ fn check_spaces_after_comma(
                 ),
                 span,
             )
-            .build(source),
+            .build_with_context(source_context),
         );
     }
 
@@ -230,7 +230,7 @@ fn check_spaces_after_comma(
                 ),
                 span,
             )
-            .build(source),
+            .build_with_context(source_context),
         );
     }
 

--- a/crates/fast-yaml-linter/src/rules/comments.rs
+++ b/crates/fast-yaml-linter/src/rules/comments.rs
@@ -87,7 +87,7 @@ impl super::LintRule for CommentsRule {
                         "comment should start with a space after '#'",
                         comment.span,
                     )
-                    .build(source),
+                    .build_with_context(context.source_context()),
                 );
             }
 
@@ -131,7 +131,7 @@ impl super::LintRule for CommentsRule {
                                 ),
                                 comment.span,
                             )
-                            .build(source),
+                            .build_with_context(context.source_context()),
                         );
                     }
                 }

--- a/crates/fast-yaml-linter/src/rules/comments_indentation.rs
+++ b/crates/fast-yaml-linter/src/rules/comments_indentation.rs
@@ -129,7 +129,7 @@ impl super::LintRule for CommentsIndentationRule {
                         ),
                         comment.span,
                     )
-                    .build(source),
+                    .build_with_context(context.source_context()),
                 );
             }
         }

--- a/crates/fast-yaml-linter/src/rules/document_end.rs
+++ b/crates/fast-yaml-linter/src/rules/document_end.rs
@@ -83,7 +83,7 @@ impl super::LintRule for DocumentEndRule {
                     ),
                     Some("\n...".to_string()),
                 )
-                .build(source),
+                .build_with_context(context.source_context()),
             ]
         }
     }

--- a/crates/fast-yaml-linter/src/rules/document_start.rs
+++ b/crates/fast-yaml-linter/src/rules/document_start.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Diagnostic, DiagnosticBuilder, DiagnosticCode, LintConfig, LintContext, Location, Severity,
-    Span,
+    SourceContext, Span,
 };
 use fast_yaml_core::Value;
 
@@ -54,15 +54,21 @@ impl super::LintRule for DocumentStartRule {
             .and_then(|rc| rc.options.get_string("present"))
             .unwrap_or("allowed");
 
+        let source_context = context.source_context();
         match presence {
-            "required" => check_required(source, config, self.code()),
-            "forbidden" => check_forbidden(source, config, self.code()),
+            "required" => check_required(source, source_context, config, self.code()),
+            "forbidden" => check_forbidden(source, source_context, config, self.code()),
             _ => Vec::new(), // "allowed" = no checks
         }
     }
 }
 
-fn check_required(source: &str, config: &LintConfig, code: &str) -> Vec<Diagnostic> {
+fn check_required(
+    source: &str,
+    source_context: &SourceContext<'_>,
+    config: &LintConfig,
+    code: &str,
+) -> Vec<Diagnostic> {
     if has_document_start_marker(source) {
         Vec::new()
     } else {
@@ -79,12 +85,17 @@ fn check_required(source: &str, config: &LintConfig, code: &str) -> Vec<Diagnost
                 Span::new(Location::new(1, 1, 0), Location::new(1, 1, 0)),
                 Some("---\n".to_string()),
             )
-            .build(source),
+            .build_with_context(source_context),
         ]
     }
 }
 
-fn check_forbidden(source: &str, config: &LintConfig, code: &str) -> Vec<Diagnostic> {
+fn check_forbidden(
+    source: &str,
+    source_context: &SourceContext<'_>,
+    config: &LintConfig,
+    code: &str,
+) -> Vec<Diagnostic> {
     if let Some((_line_num, span)) = find_document_start_marker(source) {
         let severity = config.get_effective_severity(code, Severity::Warning);
         vec![
@@ -95,7 +106,7 @@ fn check_forbidden(source: &str, config: &LintConfig, code: &str) -> Vec<Diagnos
                 span,
             )
             .with_suggestion("Remove '---'", span, None)
-            .build(source),
+            .build_with_context(source_context),
         ]
     } else {
         Vec::new()

--- a/crates/fast-yaml-linter/src/rules/duplicate_keys.rs
+++ b/crates/fast-yaml-linter/src/rules/duplicate_keys.rs
@@ -1,6 +1,8 @@
 //! Rule to detect duplicate keys in YAML mappings.
 
-use crate::{Diagnostic, DiagnosticBuilder, DiagnosticCode, LintConfig, LintContext, Severity};
+use crate::{
+    Diagnostic, DiagnosticBuilder, DiagnosticCode, LintConfig, LintContext, Severity, SourceContext,
+};
 use fast_yaml_core::Value;
 use saphyr_parser::{BufferedInput, Event, Parser as SaphyrParser};
 use std::collections::HashMap;
@@ -36,7 +38,7 @@ impl super::LintRule for DuplicateKeysRule {
         if config.allow_duplicate_keys {
             return Vec::new();
         }
-        scan_duplicate_keys(context.source())
+        scan_duplicate_keys(context.source(), context.source_context())
     }
 }
 
@@ -131,7 +133,7 @@ const fn advance_parent_to_key(scopes: &mut [ScopeKind]) {
     }
 }
 
-fn scan_duplicate_keys(source: &str) -> Vec<Diagnostic> {
+fn scan_duplicate_keys(source: &str, source_context: &SourceContext<'_>) -> Vec<Diagnostic> {
     collect_duplicates(source)
         .into_iter()
         .map(|(key, first_line, dup_line, dup_col)| {
@@ -143,7 +145,7 @@ fn scan_duplicate_keys(source: &str) -> Vec<Diagnostic> {
                 span,
             )
             .with_suggestion("remove this duplicate key or rename it", span, None)
-            .build(source)
+            .build_with_context(source_context)
         })
         .collect()
 }

--- a/crates/fast-yaml-linter/src/rules/empty_lines.rs
+++ b/crates/fast-yaml-linter/src/rules/empty_lines.rs
@@ -124,7 +124,7 @@ impl super::LintRule for EmptyLinesRule {
                                 ),
                                 span,
                             )
-                            .build(source),
+                            .build_with_context(context.source_context()),
                         );
                     }
 
@@ -159,7 +159,7 @@ impl super::LintRule for EmptyLinesRule {
                         ),
                         span,
                     )
-                    .build(source),
+                    .build_with_context(context.source_context()),
                 );
             }
         }

--- a/crates/fast-yaml-linter/src/rules/empty_values.rs
+++ b/crates/fast-yaml-linter/src/rules/empty_values.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Diagnostic, DiagnosticBuilder, DiagnosticCode, LintConfig, LintContext, Location, Severity,
-    Span, source::SourceMapper,
+    SourceContext, Span, source::SourceMapper,
 };
 use fast_yaml_core::Value;
 
@@ -73,11 +73,13 @@ impl super::LintRule for EmptyValuesRule {
 
         let mut diagnostics = Vec::new();
         let mapper = SourceMapper::new(source);
+        let source_context = context.source_context();
 
         check_value_for_empty(
             value,
             source,
             &mapper,
+            source_context,
             &mut diagnostics,
             config,
             self.code(),
@@ -95,6 +97,7 @@ fn check_value_for_empty(
     value: &Value,
     source: &str,
     mapper: &SourceMapper<'_>,
+    source_context: &SourceContext<'_>,
     diagnostics: &mut Vec<Diagnostic>,
     config: &LintConfig,
     code: &str,
@@ -125,7 +128,7 @@ fn check_value_for_empty(
                                 span,
                             )
                             .with_suggestion("Add explicit 'null'", span, Some(" null".to_string()))
-                            .build(source),
+                            .build_with_context(source_context),
                         );
                     }
                 }
@@ -135,6 +138,7 @@ fn check_value_for_empty(
                     val,
                     source,
                     mapper,
+                    source_context,
                     diagnostics,
                     config,
                     code,
@@ -164,7 +168,7 @@ fn check_value_for_empty(
                                 format!("empty value in sequence at index {idx}"),
                                 span,
                             )
-                            .build(source),
+                            .build_with_context(source_context),
                         );
                     }
                 }
@@ -173,6 +177,7 @@ fn check_value_for_empty(
                     item,
                     source,
                     mapper,
+                    source_context,
                     diagnostics,
                     config,
                     code,

--- a/crates/fast-yaml-linter/src/rules/float_values.rs
+++ b/crates/fast-yaml-linter/src/rules/float_values.rs
@@ -53,7 +53,6 @@ impl super::LintRule for FloatValuesRule {
 
     #[allow(clippy::too_many_lines)]
     fn check(&self, context: &LintContext, _value: &Value, config: &LintConfig) -> Vec<Diagnostic> {
-        let source = context.source();
         let rule_config = config.get_rule_config(self.code());
 
         let require_numeral_before_decimal = rule_config
@@ -156,7 +155,7 @@ impl super::LintRule for FloatValuesRule {
                                 ),
                                 span,
                             )
-                            .build(source),
+                            .build_with_context(context.source_context()),
                         );
                     }
                 }
@@ -186,7 +185,7 @@ impl super::LintRule for FloatValuesRule {
                             format!("scientific notation '{value_token}' is forbidden"),
                             span,
                         )
-                        .build(source),
+                        .build_with_context(context.source_context()),
                     );
                 }
 
@@ -211,7 +210,7 @@ impl super::LintRule for FloatValuesRule {
                             "NaN (not a number) is forbidden",
                             span,
                         )
-                        .build(source),
+                        .build_with_context(context.source_context()),
                     );
                 }
 
@@ -241,7 +240,7 @@ impl super::LintRule for FloatValuesRule {
                             "Infinity is forbidden",
                             span,
                         )
-                        .build(source),
+                        .build_with_context(context.source_context()),
                     );
                 }
             }

--- a/crates/fast-yaml-linter/src/rules/flow_common.rs
+++ b/crates/fast-yaml-linter/src/rules/flow_common.rs
@@ -1,7 +1,7 @@
 //! Common utilities for flow collection rules (braces, brackets).
 
 use crate::{
-    LintConfig, Severity, Span,
+    LintConfig, Severity, SourceContext, Span,
     diagnostic::{Diagnostic, DiagnosticBuilder},
 };
 
@@ -36,6 +36,7 @@ pub fn is_empty_collection(source: &str, start_offset: usize, end_offset: usize)
 /// # Arguments
 ///
 /// * `source` - The full YAML source
+/// * `source_ctx` - Pre-built source context for diagnostic extraction
 /// * `start_offset` - Byte offset after opening delimiter
 /// * `end_offset` - Byte offset of closing delimiter or next content
 /// * `min_spaces` - Minimum required spaces (-1 to disable)
@@ -48,6 +49,7 @@ pub fn is_empty_collection(source: &str, start_offset: usize, end_offset: usize)
 #[allow(clippy::too_many_arguments)]
 pub fn check_spaces_after_opening(
     source: &str,
+    source_ctx: &SourceContext<'_>,
     start_offset: usize,
     end_offset: usize,
     min_spaces: i64,
@@ -82,7 +84,7 @@ pub fn check_spaces_after_opening(
                 ),
                 opening_span,
             )
-            .build(source),
+            .build_with_context(source_ctx),
         );
     }
 
@@ -97,7 +99,7 @@ pub fn check_spaces_after_opening(
                 ),
                 opening_span,
             )
-            .build(source),
+            .build_with_context(source_ctx),
         );
     }
 
@@ -109,6 +111,7 @@ pub fn check_spaces_after_opening(
 /// # Arguments
 ///
 /// * `source` - The full YAML source
+/// * `source_ctx` - Pre-built source context for diagnostic extraction
 /// * `start_offset` - Byte offset after opening delimiter or last content
 /// * `end_offset` - Byte offset of closing delimiter
 /// * `min_spaces` - Minimum required spaces (-1 to disable)
@@ -121,6 +124,7 @@ pub fn check_spaces_after_opening(
 #[allow(clippy::too_many_arguments)]
 pub fn check_spaces_before_closing(
     source: &str,
+    source_ctx: &SourceContext<'_>,
     start_offset: usize,
     end_offset: usize,
     min_spaces: i64,
@@ -155,7 +159,7 @@ pub fn check_spaces_before_closing(
                 ),
                 closing_span,
             )
-            .build(source),
+            .build_with_context(source_ctx),
         );
     }
 
@@ -170,7 +174,7 @@ pub fn check_spaces_before_closing(
                 ),
                 closing_span,
             )
-            .build(source),
+            .build_with_context(source_ctx),
         );
     }
 
@@ -192,39 +196,82 @@ mod tests {
 
     #[test]
     fn test_check_spaces_after_opening() {
-        use crate::{Location, Span};
+        use crate::{Location, SourceContext, Span};
         let dummy_span = Span::new(Location::new(1, 1, 0), Location::new(1, 2, 1));
         let source = "{ key: value}";
+        let source_ctx = SourceContext::new(source);
         let config = LintConfig::default();
 
         // Should pass with 1 space
-        let result =
-            check_spaces_after_opening(source, 1, 13, 0, 1, "test", &config, "braces", dummy_span);
+        let result = check_spaces_after_opening(
+            source,
+            &source_ctx,
+            1,
+            13,
+            0,
+            1,
+            "test",
+            &config,
+            "braces",
+            dummy_span,
+        );
         assert!(result.is_none());
 
         // Should fail with too many spaces
         let source2 = "{  key: value}";
-        let result2 =
-            check_spaces_after_opening(source2, 1, 14, 0, 1, "test", &config, "braces", dummy_span);
+        let source_ctx2 = SourceContext::new(source2);
+        let result2 = check_spaces_after_opening(
+            source2,
+            &source_ctx2,
+            1,
+            14,
+            0,
+            1,
+            "test",
+            &config,
+            "braces",
+            dummy_span,
+        );
         assert!(result2.is_some());
     }
 
     #[test]
     fn test_check_spaces_before_closing() {
-        use crate::{Location, Span};
+        use crate::{Location, SourceContext, Span};
         let dummy_span = Span::new(Location::new(1, 13, 12), Location::new(1, 14, 13));
         let source = "{key: value }";
+        let source_ctx = SourceContext::new(source);
         let config = LintConfig::default();
 
         // Should pass with 1 space
-        let result =
-            check_spaces_before_closing(source, 1, 12, 0, 1, "test", &config, "braces", dummy_span);
+        let result = check_spaces_before_closing(
+            source,
+            &source_ctx,
+            1,
+            12,
+            0,
+            1,
+            "test",
+            &config,
+            "braces",
+            dummy_span,
+        );
         assert!(result.is_none());
 
         // Should fail with too many spaces
         let source2 = "{key: value  }";
+        let source_ctx2 = SourceContext::new(source2);
         let result2 = check_spaces_before_closing(
-            source2, 1, 13, 0, 1, "test", &config, "braces", dummy_span,
+            source2,
+            &source_ctx2,
+            1,
+            13,
+            0,
+            1,
+            "test",
+            &config,
+            "braces",
+            dummy_span,
         );
         assert!(result2.is_some());
     }

--- a/crates/fast-yaml-linter/src/rules/hyphens.rs
+++ b/crates/fast-yaml-linter/src/rules/hyphens.rs
@@ -138,7 +138,7 @@ fn check_spaces_after_hyphen(
 
             return Some(
                 DiagnosticBuilder::new(code, severity, "missing space after hyphen", span)
-                    .build(source),
+                    .build_with_context(source_context),
             );
         }
     }
@@ -157,7 +157,7 @@ fn check_spaces_after_hyphen(
                 ),
                 span,
             )
-            .build(source),
+            .build_with_context(source_context),
         );
     }
 

--- a/crates/fast-yaml-linter/src/rules/indentation.rs
+++ b/crates/fast-yaml-linter/src/rules/indentation.rs
@@ -27,7 +27,6 @@ impl super::LintRule for IndentationRule {
     }
 
     fn check(&self, context: &LintContext, _value: &Value, config: &LintConfig) -> Vec<Diagnostic> {
-        let source = context.source();
         let ctx = context.source_context();
         let indent_size = config.indent_size;
         let mut diagnostics = Vec::new();
@@ -76,7 +75,7 @@ impl super::LintRule for IndentationRule {
                     "mixed tabs and spaces in indentation".to_string(),
                     span,
                 )
-                .build(source);
+                .build_with_context(context.source_context());
                 diagnostics.push(diagnostic);
                 continue;
             }
@@ -100,7 +99,7 @@ impl super::LintRule for IndentationRule {
                     ),
                     span,
                 )
-                .build(source);
+                .build_with_context(context.source_context());
                 diagnostics.push(diagnostic);
             }
         }

--- a/crates/fast-yaml-linter/src/rules/invalid_anchors.rs
+++ b/crates/fast-yaml-linter/src/rules/invalid_anchors.rs
@@ -1,6 +1,8 @@
 //! Rule to detect duplicate anchor definitions in YAML documents.
 
-use crate::{Diagnostic, DiagnosticBuilder, DiagnosticCode, LintConfig, LintContext, Severity};
+use crate::{
+    Diagnostic, DiagnosticBuilder, DiagnosticCode, LintConfig, LintContext, Severity, SourceContext,
+};
 use fast_yaml_core::Value;
 use std::collections::HashMap;
 
@@ -43,7 +45,7 @@ impl super::LintRule for InvalidAnchorsRule {
         _value: &Value,
         _config: &LintConfig,
     ) -> Vec<Diagnostic> {
-        scan_duplicate_anchors(context.source())
+        scan_duplicate_anchors(context.source(), context.source_context())
     }
 }
 
@@ -88,7 +90,7 @@ impl ScanState {
 
 // ── Main scan function ─────────────────────────────────────────────────────
 
-fn scan_duplicate_anchors(source: &str) -> Vec<Diagnostic> {
+fn scan_duplicate_anchors(source: &str, source_context: &SourceContext<'_>) -> Vec<Diagnostic> {
     // Map from anchor name → (1-indexed line, 1-indexed column) of first def.
     let mut seen: HashMap<String, (usize, usize)> = HashMap::new();
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
@@ -151,6 +153,7 @@ fn scan_duplicate_anchors(source: &str) -> Vec<Diagnostic> {
             line_number,
             line_start_offset,
             source,
+            source_context,
             &mut state,
             &mut seen,
             &mut diagnostics,
@@ -169,7 +172,8 @@ fn scan_line_for_anchors(
     line: &str,
     line_number: usize,
     line_start_offset: usize,
-    source: &str,
+    _source: &str,
+    source_context: &SourceContext<'_>,
     state: &mut ScanState,
     seen: &mut HashMap<String, (usize, usize)>,
     diagnostics: &mut Vec<Diagnostic>,
@@ -251,7 +255,7 @@ fn scan_line_for_anchors(
                                 span,
                             )
                             .with_suggestion("rename this anchor to be unique", span, None)
-                            .build(source),
+                            .build_with_context(source_context),
                         );
                     } else {
                         seen.insert(name.to_owned(), (line_number, col));

--- a/crates/fast-yaml-linter/src/rules/key_ordering.rs
+++ b/crates/fast-yaml-linter/src/rules/key_ordering.rs
@@ -194,7 +194,7 @@ fn locate_key(key: &str, context: &LintContext<'_>, cursor: &mut usize) -> Optio
 fn emit_ordering_diagnostics(
     key_positions: &[(String, usize)],
     context: &LintContext<'_>,
-    source: &str,
+    _source: &str,
     case_sensitive: bool,
     config: &LintConfig,
     diagnostics: &mut Vec<Diagnostic>,
@@ -232,7 +232,7 @@ fn emit_ordering_diagnostics(
                         ),
                         span,
                     )
-                    .build(source),
+                    .build_with_context(context.source_context()),
                 );
             }
         }

--- a/crates/fast-yaml-linter/src/rules/line_length.rs
+++ b/crates/fast-yaml-linter/src/rules/line_length.rs
@@ -65,7 +65,7 @@ impl super::LintRule for LineLengthRule {
                         ),
                         span,
                     )
-                    .build(source);
+                    .build_with_context(context.source_context());
 
                     diagnostics.push(diagnostic);
                 }

--- a/crates/fast-yaml-linter/src/rules/new_line_at_end_of_file.rs
+++ b/crates/fast-yaml-linter/src/rules/new_line_at_end_of_file.rs
@@ -74,7 +74,7 @@ impl super::LintRule for NewLineAtEndOfFileRule {
                     ),
                     Some("\n".to_string()),
                 )
-                .build(source),
+                .build_with_context(context.source_context()),
             ]
         }
     }

--- a/crates/fast-yaml-linter/src/rules/new_lines.rs
+++ b/crates/fast-yaml-linter/src/rules/new_lines.rs
@@ -112,7 +112,7 @@ impl super::LintRule for NewLinesRule {
                             ),
                             span,
                         )
-                        .build(source),
+                        .build_with_context(context.source_context()),
                     );
                 }
 

--- a/crates/fast-yaml-linter/src/rules/octal_values.rs
+++ b/crates/fast-yaml-linter/src/rules/octal_values.rs
@@ -130,7 +130,7 @@ impl super::LintRule for OctalValuesRule {
                             ),
                             span,
                         )
-                        .build(source),
+                        .build_with_context(context.source_context()),
                     );
                 }
 
@@ -163,7 +163,7 @@ impl super::LintRule for OctalValuesRule {
                                 ),
                                 span,
                             )
-                            .build(source),
+                            .build_with_context(context.source_context()),
                         );
                     }
                 }

--- a/crates/fast-yaml-linter/src/rules/quoted_strings.rs
+++ b/crates/fast-yaml-linter/src/rules/quoted_strings.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Diagnostic, DiagnosticBuilder, DiagnosticCode, LintConfig, LintContext, Location, Severity,
-    Span,
+    SourceContext, Span,
 };
 use fast_yaml_core::Value;
 use saphyr_parser::{BufferedInput, Event, Parser as SaphyrParser, ScalarStyle};
@@ -127,6 +127,7 @@ impl super::LintRule for QuotedStringsRule {
 
                     self.check_scalar(
                         source,
+                        context.source_context(),
                         config,
                         &mut diagnostics,
                         value,
@@ -162,7 +163,8 @@ impl QuotedStringsRule {
     #[allow(clippy::too_many_arguments)]
     fn check_scalar(
         &self,
-        source: &str,
+        _source: &str,
+        source_ctx: &SourceContext<'_>,
         config: &LintConfig,
         diagnostics: &mut Vec<Diagnostic>,
         value: &str,
@@ -196,7 +198,7 @@ impl QuotedStringsRule {
                             "string should use single quotes",
                             scalar_span,
                         )
-                        .build(source),
+                        .build_with_context(source_ctx),
                     );
                 } else if quote_type == "double" && quote_char == '\'' {
                     let severity =
@@ -208,7 +210,7 @@ impl QuotedStringsRule {
                             "string should use double quotes",
                             scalar_span,
                         )
-                        .build(source),
+                        .build_with_context(source_ctx),
                     );
                 }
 
@@ -225,7 +227,7 @@ impl QuotedStringsRule {
                                 "string does not need quotes",
                                 scalar_span,
                             )
-                            .build(source),
+                            .build_with_context(source_ctx),
                         );
                     }
                 } else if required == "never" {
@@ -238,7 +240,7 @@ impl QuotedStringsRule {
                             "string should not be quoted",
                             scalar_span,
                         )
-                        .build(source),
+                        .build_with_context(source_ctx),
                     );
                 }
             }
@@ -260,7 +262,7 @@ impl QuotedStringsRule {
                             "string should be quoted",
                             scalar_span,
                         )
-                        .build(source),
+                        .build_with_context(source_ctx),
                     );
                 }
             }

--- a/crates/fast-yaml-linter/src/rules/trailing_whitespace.rs
+++ b/crates/fast-yaml-linter/src/rules/trailing_whitespace.rs
@@ -32,7 +32,6 @@ impl super::LintRule for TrailingWhitespaceRule {
         _value: &Value,
         _config: &LintConfig,
     ) -> Vec<Diagnostic> {
-        let source = context.source();
         let mut diagnostics = Vec::new();
         let ctx = context.source_context();
 
@@ -70,7 +69,7 @@ impl super::LintRule for TrailingWhitespaceRule {
                         span,
                     )
                     .with_suggestion("remove trailing whitespace", span, None)
-                    .build(source);
+                    .build_with_context(context.source_context());
 
                     diagnostics.push(diagnostic);
                 }

--- a/crates/fast-yaml-linter/src/rules/truthy.rs
+++ b/crates/fast-yaml-linter/src/rules/truthy.rs
@@ -59,7 +59,6 @@ impl super::LintRule for TruthyRule {
 
     #[allow(clippy::too_many_lines)]
     fn check(&self, context: &LintContext, _value: &Value, config: &LintConfig) -> Vec<Diagnostic> {
-        let source = context.source();
         let rule_config = config.get_rule_config(self.code());
 
         let allowed_values = rule_config
@@ -123,7 +122,7 @@ impl super::LintRule for TruthyRule {
                                 ),
                                 span,
                             )
-                            .build(source),
+                            .build_with_context(context.source_context()),
                         );
                     }
                 }
@@ -170,7 +169,7 @@ impl super::LintRule for TruthyRule {
                             ),
                             span,
                         )
-                        .build(source),
+                        .build_with_context(context.source_context()),
                     );
                 }
             }
@@ -223,7 +222,7 @@ impl super::LintRule for TruthyRule {
                             ),
                             span,
                         )
-                        .build(source),
+                        .build_with_context(context.source_context()),
                     );
                 }
             }


### PR DESCRIPTION
## Summary

- Add `build_with_context(source_ctx: &SourceContext<'_>)` to `DiagnosticBuilder` so linting rules reuse the pre-built `SourceContext` from `LintContext` instead of calling `SourceContext::new()` once per diagnostic
- Update all 40+ call sites across 22 rule files to use `build_with_context`
- Keep `build(source: &str)` for backward compatibility
- Fix broken intra-doc link in `diagnostic.rs`

## Performance

Before (O(n²) scaling):
- 1k keys: ~16ms
- 5k keys: ~266ms
- 10k keys: ~1003ms

After (O(n) scaling):
- 1k keys: ~13ms
- 5k keys: ~20ms
- 10k keys: ~33ms

**30× improvement on 10k-key files.**

## Test plan

- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo clippy --workspace ... -D warnings` — 0 warnings
- [x] `cargo nextest run --workspace ...` — 1029 passed, 3 skipped
- [x] `cargo deny check` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace ...` — clean

Closes #157