### PR TITLE
fix(linter): comments-indentation false positive on top-level comment after nested block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - fix(linter): correct `hyphens` rule false positives on list items following non-ASCII (multibyte) characters by using byte-level indexing instead of `chars().nth(offset)` (#161)
+- fix(linter): `comments-indentation` rule no longer emits false-positive diagnostics for column-0 comments that follow a nested block; column-0 comments are always valid top-level comments and are skipped unconditionally (#166)
 - fix(linter): `comments` rule no longer emits false-positive diagnostics for `#` characters inside block scalars (`|` and `>`); block scalar context is now tracked by indentation level (#160)
 - fix(linter): `float-values` suggestion for signed leading-dot floats now correctly inserts `0` after the sign character (`-.5` → `-0.5`, `+.5` → `+0.5`) instead of prepending `0` before the sign (#159)
 - fix(linter): replace O(n²) `compute_offset` in `quoted-strings` rule with O(1) `SourceContext::get_line_offset` lookup (#147)

--- a/crates/fast-yaml-linter/src/rules/comments_indentation.rs
+++ b/crates/fast-yaml-linter/src/rules/comments_indentation.rs
@@ -100,8 +100,14 @@ impl super::LintRule for CommentsIndentationRule {
                 break;
             }
 
-            // If no content found after, check previous content line
+            // If no content found after, check previous content line.
+            // Column-0 comments always belong to the top level, so skip the
+            // backward-scan entirely — using indentation from a preceding nested
+            // block would produce a false-positive diagnostic.
             if expected_indent.is_none() {
+                if comment_indent == 0 {
+                    continue;
+                }
                 for info in line_info.iter().take(comment_line_idx).rev() {
                     // Skip empty lines and comment lines
                     if info.is_empty || info.is_comment {
@@ -278,5 +284,92 @@ mod tests {
         let context = LintContext::new(yaml);
         let diagnostics = rule.check(&context, &value, &config);
         assert!(diagnostics.is_empty());
+    }
+
+    // Regression tests for issue #166: top-level comment after nested block false positive
+
+    #[test]
+    fn test_toplevel_comment_after_nested_block() {
+        // Top-level comment after a nested block should not be flagged
+        let yaml = "a:\n  b: 2\n# top-level comment\nc: 3\n";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = CommentsIndentationRule;
+        let config = LintConfig::default();
+
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &config);
+        assert!(
+            diagnostics.is_empty(),
+            "top-level comment after nested block should not produce diagnostics"
+        );
+    }
+
+    #[test]
+    fn test_toplevel_comment_at_start() {
+        // Top-level comment before any content should not be flagged
+        let yaml = "# top-level header\na: 1\nb: 2\n";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = CommentsIndentationRule;
+        let config = LintConfig::default();
+
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &config);
+        assert!(
+            diagnostics.is_empty(),
+            "top-level comment at file start should not produce diagnostics"
+        );
+    }
+
+    #[test]
+    fn test_toplevel_comment_between_top_level_keys() {
+        // Top-level comment between two top-level keys should not be flagged
+        let yaml = "a: 1\n# separator\nb: 2\n";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = CommentsIndentationRule;
+        let config = LintConfig::default();
+
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &config);
+        assert!(
+            diagnostics.is_empty(),
+            "top-level comment between top-level keys should not produce diagnostics"
+        );
+    }
+
+    #[test]
+    fn test_indented_comment_in_nested_block_still_checked() {
+        // A comment indented to match nested block should still work correctly
+        let yaml = "root:\n  nested:\n    # comment at level 2\n    key: value\n";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = CommentsIndentationRule;
+        let config = LintConfig::default();
+
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &config);
+        assert!(
+            diagnostics.is_empty(),
+            "correctly indented nested comment should not produce diagnostics"
+        );
+    }
+
+    #[test]
+    fn test_indented_comment_wrong_level_still_flagged() {
+        // A comment with wrong indentation inside a nested block should still be flagged
+        let yaml = "root:\n  nested:\n  # wrong level comment\n    key: value\n";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = CommentsIndentationRule;
+        let config = LintConfig::default();
+
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &config);
+        assert!(
+            !diagnostics.is_empty(),
+            "incorrectly indented nested comment should produce diagnostics"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #166: the `comments-indentation` rule was flagging column-0 comments that appear after a nested mapping block
- Root cause: the backward-scan fallback used the indentation of the last preceding line as expected indent, without accounting for dedent back to root scope
- Fix: add an early-exit guard in the backward-scan path — when no forward content follows and `comment_indent == 0`, skip the check entirely (column-0 comments are always valid top-level comments)

## Test plan

- [x] `test_toplevel_comment_after_nested_block` — reproduction case from issue #166
- [x] `test_toplevel_comment_at_start` — column-0 comment at file start
- [x] `test_toplevel_comment_between_top_level_keys` — comment between two root-level keys
- [x] `test_indented_comment_in_nested_block_still_checked` — correctly indented nested comment still passes
- [x] `test_indented_comment_wrong_level_still_flagged` — wrong-level nested comment still flagged
- [x] All 1037 tests pass, 0 clippy warnings