### PR TITLE
fix(linter): correct empty-values position and add lint glob/dir support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **CLI**: `fy lint` now accepts multiple `PATHS...` arguments (files, directories, glob patterns), mirrors the `fy format` batch mode. Supports `--include`/`--exclude` glob filters, `--no-recursive`, and `-j`/`--jobs` for parallel processing. Exit code is non-zero when any file has Error-severity diagnostics. (#165)
 - **CLI**: `fy lint` now supports a `--config <path>` flag to load rule configuration from a YAML file. Auto-discovery walks up from the current working directory looking for `.fast-yaml.yaml` or `.fast-yaml.yml` (up to 20 directory levels). Use `--no-config` to disable auto-discovery. (#123)
 - **CLI**: `--max-line-length`, `--indent-size`, and `--allow-duplicate-keys` flags on `fy lint` now use `Option<T>` so they only override config file values when explicitly provided; defaults are no longer silently applied over config file settings.
 - **Linter**: `ConfigFile` and `ConfigFileError` types in `fast-yaml-linter` for loading and merging `.fast-yaml.yaml` config files into `LintConfig`. Unknown rule names emit a warning to stderr.
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(linter): `quoted-strings` rule no longer emits "does not need quotes" for double-quoted strings that contain YAML escape sequences (`\n`, `\t`, `\\`, `\"`, `\uXXXX`, etc.); removing quotes would silently corrupt the value (#175)
 - fix(linter): `octal-values` rule no longer fires on octal patterns (`0o\d+`, `0\d+`) found inside YAML comment lines or inline comments (#176)
 - fix(linter): `octal-values` diagnostic position now points to the octal value token, not to column 1 of the mapping key (#177)
+- fix(linter): `empty-values` rule reported wrong line/column when a key name appeared as a substring of an earlier key (e.g. `a` matched inside `parent`). All three helpers (`find_empty_value_span`, `has_explicit_null_value`, `is_in_flow_mapping`) now use exact boundary matching instead of plain substring search. (#174)
 - fix(linter): correct `hyphens` rule false positives on list items following non-ASCII (multibyte) characters by using byte-level indexing instead of `chars().nth(offset)` (#161)
 - fix(linter): `comments-indentation` rule no longer emits false-positive diagnostics for column-0 comments that follow a nested block; column-0 comments are always valid top-level comments and are skipped unconditionally (#166)
 - fix(python): `LintConfig(disabled_rules=...)` now accepts any iterable (list, tuple, set) instead of requiring a set; the argument is converted to a set internally (#168)

--- a/crates/fast-yaml-cli/src/cli.rs
+++ b/crates/fast-yaml-cli/src/cli.rs
@@ -109,8 +109,10 @@ pub enum Command {
     #[cfg(feature = "linter")]
     /// Lint YAML with diagnostics
     Lint {
-        /// Input file (default: stdin)
-        file: Option<PathBuf>,
+        /// Input paths (files, directories, or glob patterns).
+        /// If empty, reads from stdin.
+        #[arg(value_name = "PATHS")]
+        paths: Vec<PathBuf>,
 
         /// Path to config file (default: auto-discover .fast-yaml.yaml)
         #[arg(long, value_name = "FILE", conflicts_with = "no_config")]
@@ -135,6 +137,22 @@ pub enum Command {
         /// Allow duplicate keys — overrides config file (opt-in, suppresses duplicate key errors)
         #[arg(long, num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set)]
         allow_duplicate_keys: Option<bool>,
+
+        /// Include files matching glob pattern (can be repeated)
+        #[arg(long)]
+        include: Vec<String>,
+
+        /// Exclude files matching glob pattern (can be repeated)
+        #[arg(long)]
+        exclude: Vec<String>,
+
+        /// Don't recurse into subdirectories
+        #[arg(long)]
+        no_recursive: bool,
+
+        /// Number of parallel jobs (0 = auto-detect)
+        #[arg(short = 'j', long, default_value = "0")]
+        jobs: usize,
     },
 }
 

--- a/crates/fast-yaml-cli/src/commands/lint.rs
+++ b/crates/fast-yaml-cli/src/commands/lint.rs
@@ -28,7 +28,8 @@ pub struct LintArgs {
 /// Lint command implementation
 pub struct LintCommand {
     config: CommonConfig,
-    lint_config: LintConfig,
+    /// Resolved lint configuration (exposed for batch reuse).
+    pub lint_config: LintConfig,
     format: LintFormat,
 }
 

--- a/crates/fast-yaml-cli/src/commands/lint_batch.rs
+++ b/crates/fast-yaml-cli/src/commands/lint_batch.rs
@@ -1,0 +1,154 @@
+//! Batch lint command execution.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use fast_yaml_linter::{Formatter, JsonFormatter, LintConfig, Linter, Severity, TextFormatter};
+use rayon::prelude::*;
+
+use crate::cli::LintFormat;
+use crate::config::CommonConfig;
+use crate::discovery::{DiscoveryConfig, FileDiscovery};
+use crate::error::ExitCode;
+
+/// Configuration for batch lint execution.
+#[derive(Debug, Clone)]
+pub struct LintBatchConfig {
+    /// Common configuration
+    pub common: CommonConfig,
+    /// Discovery-specific configuration
+    pub discovery: DiscoveryConfig,
+    /// Lint configuration
+    pub lint_config: LintConfig,
+    /// Lint output format
+    pub format: LintFormat,
+}
+
+impl LintBatchConfig {
+    pub fn new(common: CommonConfig, lint_config: LintConfig, format: LintFormat) -> Self {
+        Self {
+            common,
+            discovery: DiscoveryConfig::new(),
+            lint_config,
+            format,
+        }
+    }
+
+    #[must_use]
+    pub fn with_discovery(mut self, discovery: DiscoveryConfig) -> Self {
+        self.discovery = discovery;
+        self
+    }
+}
+
+/// Execute batch linting on multiple files.
+///
+/// # Errors
+///
+/// Returns error if file discovery fails.
+pub fn execute_lint_batch(config: &LintBatchConfig, paths: &[PathBuf]) -> Result<ExitCode> {
+    let discovery = FileDiscovery::new(config.discovery.clone())
+        .context("Failed to initialize file discovery")?;
+
+    let files = discovery
+        .discover(paths)
+        .context("Failed to discover files")?;
+
+    if files.is_empty() {
+        if !config.common.output.is_quiet() {
+            eprintln!("No YAML files found");
+        }
+        return Ok(ExitCode::Success);
+    }
+
+    let workers = config
+        .common
+        .parallel
+        .workers()
+        .unwrap_or_else(rayon::current_num_threads);
+
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(workers)
+        .build()
+        .context("Failed to build thread pool")?;
+
+    let lint_config = config.lint_config.clone();
+    let format = config.format.clone();
+    let use_color = config.common.output.use_color();
+    let is_quiet = config.common.output.is_quiet();
+
+    let file_paths: Vec<PathBuf> = files.iter().map(|f| f.path.clone()).collect();
+
+    // Process files in parallel, collecting (path, output, has_errors) tuples
+    let results: Vec<(PathBuf, String, bool)> = pool.install(|| {
+        file_paths
+            .par_iter()
+            .map(|path| {
+                let content = match std::fs::read_to_string(path) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let msg = format!("error: failed to read '{}': {e}\n", path.display());
+                        return (path.clone(), msg, true);
+                    }
+                };
+
+                let linter = Linter::with_config(lint_config.clone());
+                let diagnostics = match linter.lint(&content) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        let msg = format!("error: '{}': {e}\n", path.display());
+                        return (path.clone(), msg, true);
+                    }
+                };
+
+                let filtered: Vec<_> = if is_quiet {
+                    diagnostics
+                        .into_iter()
+                        .filter(|d| d.severity == Severity::Error)
+                        .collect()
+                } else {
+                    diagnostics
+                };
+
+                let has_errors = filtered.iter().any(|d| d.severity == Severity::Error);
+
+                let output = match format {
+                    LintFormat::Text => {
+                        let mut formatter = TextFormatter::new();
+                        formatter.use_color = use_color;
+                        formatter.format(&filtered, &content)
+                    }
+                    LintFormat::Json => {
+                        let formatter = JsonFormatter::new(true);
+                        formatter.format(&filtered, &content)
+                    }
+                };
+
+                // Prefix output with the file path when linting multiple files
+                let prefixed = if output.is_empty() {
+                    output
+                } else {
+                    format!("{}:\n{}", path.display(), output)
+                };
+
+                (path.clone(), prefixed, has_errors)
+            })
+            .collect()
+    });
+
+    let mut any_errors = false;
+    for (_path, output, has_errors) in &results {
+        if !output.is_empty() {
+            print!("{output}");
+        }
+        if *has_errors {
+            any_errors = true;
+        }
+    }
+
+    if any_errors {
+        Ok(ExitCode::LintErrors)
+    } else {
+        Ok(ExitCode::Success)
+    }
+}

--- a/crates/fast-yaml-cli/src/commands/mod.rs
+++ b/crates/fast-yaml-cli/src/commands/mod.rs
@@ -5,3 +5,6 @@ pub mod parse;
 
 #[cfg(feature = "linter")]
 pub mod lint;
+
+#[cfg(feature = "linter")]
+pub mod lint_batch;

--- a/crates/fast-yaml-cli/src/main.rs
+++ b/crates/fast-yaml-cli/src/main.rs
@@ -46,6 +46,7 @@ mod reporter;
 
 use cli::{Cli, Command};
 use error::{ExitCode, format_error};
+use io::input::InputOrigin;
 use io::{InputSource, OutputWriter};
 
 fn main() {
@@ -172,25 +173,94 @@ fn run() -> Result<ExitCode> {
         }
         #[cfg(feature = "linter")]
         Some(Command::Lint {
-            file,
+            paths,
             config: config_path,
             no_config,
             max_line_length,
             indent_size,
             format,
             allow_duplicate_keys,
+            include,
+            exclude,
+            no_recursive,
+            jobs,
         }) => {
-            let input = InputSource::from_args(file)?;
-            let args = commands::lint::LintArgs {
-                config_path,
-                no_config,
-                max_line_length,
-                indent_size,
-                format,
-                allow_duplicate_keys,
-            };
-            let cmd = commands::lint::LintCommand::build(common_config.clone(), args, &input)?;
-            cmd.execute(&input)?
+            let is_batch = is_batch_mode(&paths, false, &include, &exclude, jobs);
+
+            if is_batch {
+                // BATCH MODE — multiple files, directories, or glob patterns
+                let mut discovery_config = discovery::DiscoveryConfig::new();
+                if !include.is_empty() {
+                    discovery_config = discovery_config.with_include_patterns(include);
+                }
+                if !exclude.is_empty() {
+                    discovery_config = discovery_config.with_exclude_patterns(exclude);
+                }
+                if no_recursive {
+                    discovery_config = discovery_config.with_max_depth(Some(1));
+                }
+
+                // Build lint config using same logic as single-file mode.
+                // Use a synthetic stdin input for config discovery (CWD-based, same as yamllint).
+                let stdin_fallback = InputSource {
+                    content: String::new(),
+                    origin: InputOrigin::Stdin,
+                };
+                let args = commands::lint::LintArgs {
+                    config_path,
+                    no_config,
+                    max_line_length,
+                    indent_size,
+                    format: format.clone(),
+                    allow_duplicate_keys,
+                };
+                let cmd = commands::lint::LintCommand::build(
+                    common_config.clone(),
+                    args,
+                    &stdin_fallback,
+                )?;
+
+                let batch_config = commands::lint_batch::LintBatchConfig::new(
+                    common_config.clone().with_parallel(
+                        config::ParallelConfig::new().with_workers(if jobs == 0 {
+                            None
+                        } else {
+                            Some(jobs)
+                        }),
+                    ),
+                    cmd.lint_config,
+                    format,
+                )
+                .with_discovery(discovery_config);
+
+                commands::lint_batch::execute_lint_batch(&batch_config, &paths)?
+            } else if paths.is_empty() {
+                // STDIN MODE
+                let input = InputSource::from_stdin()?;
+                let args = commands::lint::LintArgs {
+                    config_path,
+                    no_config,
+                    max_line_length,
+                    indent_size,
+                    format,
+                    allow_duplicate_keys,
+                };
+                let cmd = commands::lint::LintCommand::build(common_config.clone(), args, &input)?;
+                cmd.execute(&input)?
+            } else {
+                // SINGLE FILE MODE
+                let input = InputSource::from_file(&paths[0])?;
+                let args = commands::lint::LintArgs {
+                    config_path,
+                    no_config,
+                    max_line_length,
+                    indent_size,
+                    format,
+                    allow_duplicate_keys,
+                };
+                let cmd = commands::lint::LintCommand::build(common_config.clone(), args, &input)?;
+                cmd.execute(&input)?
+            }
         }
         None => {
             // Default: parse and format (passthrough) from stdin

--- a/crates/fast-yaml-linter/src/rules/empty_values.rs
+++ b/crates/fast-yaml-linter/src/rules/empty_values.rs
@@ -192,16 +192,11 @@ fn check_value_for_empty(
 }
 
 fn has_explicit_null_value(_source: &str, key: &str, mapper: &SourceMapper<'_>) -> bool {
-    // Find the key in source
     for line_num in 1..=mapper.context().line_count() {
-        if let Some(line) = mapper.context().get_line(line_num)
-            && let Some(key_pos) = line.find(key)
-        {
-            // Check what comes after the key and colon
-            let after_key = &line[key_pos + key.len()..];
-            if let Some(colon_pos) = after_key.find(':') {
-                let after_colon = after_key[colon_pos + 1..].trim();
-                // Check for explicit null values or any explicit type tag (!!/!)
+        if let Some(line) = mapper.context().get_line(line_num) {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with(key) && trimmed[key.len()..].starts_with(':') {
+                let after_colon = trimmed[key.len() + 1..].trim();
                 if after_colon.starts_with("null")
                     || after_colon.starts_with('~')
                     || after_colon.starts_with("Null")
@@ -219,13 +214,26 @@ fn has_explicit_null_value(_source: &str, key: &str, mapper: &SourceMapper<'_>) 
 }
 
 fn is_in_flow_mapping(source: &str, key: &str) -> bool {
+    // Key-colon pattern to search for
+    let key_colon = format!("{key}:");
     for line in source.lines() {
-        if let Some(key_pos) = line.find(key) {
-            // Check if there's a '{' before the key on the same line
-            let before = &line[..key_pos];
-            if before.contains('{') {
-                return true;
+        // Find all occurrences of "key:" on the line
+        let mut search_from = 0;
+        while let Some(pos) = line[search_from..].find(key_colon.as_str()) {
+            let abs_pos = search_from + pos;
+            // Verify exact boundary: char before key must not be alphanumeric/underscore/hyphen
+            let before_ok = abs_pos == 0
+                || !line
+                    .as_bytes()
+                    .get(abs_pos - 1)
+                    .is_some_and(|b| b.is_ascii_alphanumeric() || *b == b'_' || *b == b'-');
+            if before_ok {
+                // Check if there's a '{' before this position on the same line
+                if line[..abs_pos].contains('{') {
+                    return true;
+                }
             }
+            search_from = abs_pos + 1;
         }
     }
 
@@ -233,21 +241,49 @@ fn is_in_flow_mapping(source: &str, key: &str) -> bool {
 }
 
 fn find_empty_value_span(_source: &str, key: &str, mapper: &SourceMapper<'_>) -> Option<Span> {
+    let key_colon = format!("{key}:");
     for line_num in 1..=mapper.context().line_count() {
-        if let Some(line) = mapper.context().get_line(line_num)
-            && let Some(key_pos) = line.find(key)
-            && let Some(colon_pos) = line[key_pos..].find(':')
-        {
-            let abs_colon_pos = key_pos + colon_pos;
-            let line_offset: usize = (1..line_num)
-                .filter_map(|ln| mapper.context().get_line(ln))
-                .map(|l| l.len() + 1)
-                .sum();
+        if let Some(line) = mapper.context().get_line(line_num) {
+            let trimmed = line.trim_start();
+            let indent = line.len() - trimmed.len();
 
-            return Some(Span::new(
-                Location::new(line_num, abs_colon_pos + 1, line_offset + abs_colon_pos),
-                Location::new(line_num, abs_colon_pos + 2, line_offset + abs_colon_pos + 1),
-            ));
+            // Block mapping: key starts trimmed line
+            if trimmed.starts_with(key) && trimmed[key.len()..].starts_with(':') {
+                let abs_colon_pos = indent + key.len();
+                let line_offset: usize = (1..line_num)
+                    .filter_map(|ln| mapper.context().get_line(ln))
+                    .map(|l| l.len() + 1)
+                    .sum();
+
+                return Some(Span::new(
+                    Location::new(line_num, abs_colon_pos + 1, line_offset + abs_colon_pos),
+                    Location::new(line_num, abs_colon_pos + 2, line_offset + abs_colon_pos + 1),
+                ));
+            }
+
+            // Flow mapping: key appears after '{' or ',' on the same line
+            let mut search_from = 0;
+            while let Some(rel_pos) = line[search_from..].find(key_colon.as_str()) {
+                let abs_pos = search_from + rel_pos;
+                let before_ok = abs_pos == 0
+                    || !line
+                        .as_bytes()
+                        .get(abs_pos - 1)
+                        .is_some_and(|b| b.is_ascii_alphanumeric() || *b == b'_' || *b == b'-');
+                if before_ok && line[..abs_pos].contains('{') {
+                    let abs_colon_pos = abs_pos + key.len();
+                    let line_offset: usize = (1..line_num)
+                        .filter_map(|ln| mapper.context().get_line(ln))
+                        .map(|l| l.len() + 1)
+                        .sum();
+
+                    return Some(Span::new(
+                        Location::new(line_num, abs_colon_pos + 1, line_offset + abs_colon_pos),
+                        Location::new(line_num, abs_colon_pos + 2, line_offset + abs_colon_pos + 1),
+                    ));
+                }
+                search_from = abs_pos + 1;
+            }
         }
     }
 
@@ -433,6 +469,45 @@ mod tests {
         assert!(
             diagnostics.is_empty(),
             "!!int 42 should not trigger empty-values"
+        );
+    }
+
+    #[test]
+    fn test_empty_value_position_not_confused_by_key_substring() {
+        // Regression for #174: key "a" must not match inside "parent" on line 1.
+        // Diagnostic for "a" must point to line 2, not line 1.
+        let yaml = "parent:\n  a:\n  b: 1\n";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = EmptyValuesRule;
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &LintConfig::new());
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.start.line, 2,
+            "diagnostic must be on line 2"
+        );
+        assert_eq!(
+            diagnostics[0].span.start.column, 4,
+            "diagnostic must point to the colon"
+        );
+    }
+
+    #[test]
+    fn test_empty_value_position_prefix_key() {
+        // Key "pa" must not match inside "parent" on line 1.
+        let yaml = "parent:\n  pa:\n  b: 1\n";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = EmptyValuesRule;
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &LintConfig::new());
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.start.line, 2,
+            "diagnostic must be on line 2"
         );
     }
 


### PR DESCRIPTION
## Summary

- **#174** Fix `empty-values` rule reporting wrong line/column when a parent key's colon column is ≥ the nested empty key's column. Root cause: `line.find(key)` matched the key as a substring inside longer parent keys (e.g. `"parent"` contains `"a"`). Fixed by replacing with exact boundary check in all three helpers (`find_empty_value_span`, `has_explicit_null_value`, `is_in_flow_mapping`).

- **#165** Add directory/glob/multi-path support to `fy lint` matching `fy format`. Accepts `Vec<PathBuf>` with `--include`/`--exclude`/`--no-recursive`/`--jobs` flags, reusing `FileDiscovery` and rayon-based batch processing from `format_batch`.

## Test plan

- [ ] Regression tests `test_empty_value_position_not_confused_by_key_substring` and `test_empty_value_position_prefix_key` pass for #174
- [ ] `cargo nextest run --workspace --exclude fast-yaml --exclude fast-yaml-nodejs` — 1035/1035 pass
- [ ] Manual: `printf 'parent:\n  a:\n  b: 1\n' | fy lint -` reports `input:2:4` (was `input:1:7`)
- [ ] Manual: `fy lint .` lints all YAML files in current directory
- [ ] Manual: `fy lint 'k8s/**/*.yaml'` works with glob patterns

Closes #174
Closes #165