### PR TITLE
fix(linter): correct false positives in quoted-strings and octal-values rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix(linter): `quoted-strings` rule no longer emits "does not need quotes" for double-quoted strings that contain YAML escape sequences (`\n`, `\t`, `\\`, `\"`, `\uXXXX`, etc.); removing quotes would silently corrupt the value (#175)
+- fix(linter): `octal-values` rule no longer fires on octal patterns (`0o\d+`, `0\d+`) found inside YAML comment lines or inline comments (#176)
+- fix(linter): `octal-values` diagnostic position now points to the octal value token, not to column 1 of the mapping key (#177)
 - fix(linter): correct `hyphens` rule false positives on list items following non-ASCII (multibyte) characters by using byte-level indexing instead of `chars().nth(offset)` (#161)
 - fix(linter): `comments-indentation` rule no longer emits false-positive diagnostics for column-0 comments that follow a nested block; column-0 comments are always valid top-level comments and are skipped unconditionally (#166)
 - fix(python): `LintConfig(disabled_rules=...)` now accepts any iterable (list, tuple, set) instead of requiring a set; the argument is converted to a set internally (#168)

--- a/crates/fast-yaml-linter/src/rules/octal_values.rs
+++ b/crates/fast-yaml-linter/src/rules/octal_values.rs
@@ -6,6 +6,25 @@ use crate::{
 };
 use fast_yaml_core::Value;
 
+use super::LintRule as _;
+
+/// Returns the portion of a YAML source line before any inline comment.
+///
+/// A `#` starts a comment only when preceded by whitespace (or at start of line).
+/// This avoids stripping `#` characters inside quoted strings — the caller already
+/// skips quoted values, so the approximation is sufficient for value scanning.
+fn strip_inline_comment(line: &str) -> &str {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'#' && (i == 0 || bytes[i - 1] == b' ' || bytes[i - 1] == b'\t') {
+            return &line[..i];
+        }
+        i += 1;
+    }
+    line
+}
+
 /// Linting rule for octal values.
 ///
 /// Forbids unquoted octal numbers to prevent ambiguity:
@@ -55,7 +74,6 @@ impl super::LintRule for OctalValuesRule {
         let forbid_implicit = rule_config
             .and_then(|rc| rc.options.get_bool("forbid-implicit-octal"))
             .unwrap_or(true);
-
         let forbid_explicit = rule_config
             .and_then(|rc| rc.options.get_bool("forbid-explicit-octal"))
             .unwrap_or(true);
@@ -65,112 +83,145 @@ impl super::LintRule for OctalValuesRule {
         }
 
         let mut diagnostics = Vec::new();
-        let _source_context = context.source_context();
-
-        // Pattern: value part after colon or hyphen
         for (line_idx, line) in source.lines().enumerate() {
             let line_num = line_idx + 1;
             let line_offset = context.source_context().get_line_offset(line_num);
-
-            // Find value parts (after : or -)
-            let parts: Vec<_> = line.find(':').map_or_else(
-                || {
-                    if line.trim_start().starts_with('-') {
-                        line.find('-')
-                            .map_or_else(Vec::new, |hyphen_pos| vec![&line[hyphen_pos + 1..]])
-                    } else {
-                        vec![]
-                    }
-                },
-                |colon_pos| vec![&line[colon_pos + 1..]],
+            self.check_line(
+                context,
+                config,
+                &mut diagnostics,
+                line,
+                line_num,
+                line_offset,
+                forbid_implicit,
+                forbid_explicit,
             );
+        }
+        diagnostics
+    }
+}
 
-            for part in parts {
-                let trimmed = part.trim();
+impl OctalValuesRule {
+    #[allow(clippy::too_many_arguments)]
+    fn check_line(
+        &self,
+        context: &LintContext,
+        config: &LintConfig,
+        diagnostics: &mut Vec<Diagnostic>,
+        line: &str,
+        line_num: usize,
+        line_offset: usize,
+        forbid_implicit: bool,
+        forbid_explicit: bool,
+    ) {
+        // Strip inline comment before scanning for octal tokens.
+        let line_without_comment = strip_inline_comment(line);
 
-                // Skip if empty or quoted
-                if trimmed.is_empty()
-                    || trimmed.starts_with('"')
-                    || trimmed.starts_with('\'')
-                    || trimmed.starts_with('[')
-                    || trimmed.starts_with('{')
-                {
-                    continue;
+        // Skip pure comment lines.
+        if line_without_comment.trim_start().starts_with('#') {
+            return;
+        }
+
+        // Find value parts (after : or -)
+        let parts: Vec<(usize, &str)> = line_without_comment.find(':').map_or_else(
+            || {
+                if line_without_comment.trim_start().starts_with('-') {
+                    line_without_comment
+                        .find('-')
+                        .map_or_else(Vec::new, |hyphen_pos| {
+                            vec![(hyphen_pos + 1, &line_without_comment[hyphen_pos + 1..])]
+                        })
+                } else {
+                    vec![]
                 }
+            },
+            |colon_pos| vec![(colon_pos + 1, &line_without_comment[colon_pos + 1..])],
+        );
 
-                // Extract the value token (before any comment or space)
-                let value_token = trimmed
-                    .split_whitespace()
-                    .next()
-                    .and_then(|s| s.split('#').next())
-                    .unwrap_or(trimmed);
+        for (part_start_in_line, part) in parts {
+            let trimmed = part.trim_start();
 
-                // Check for explicit octal (0o prefix)
-                if forbid_explicit
-                    && value_token.starts_with("0o")
-                    && let Some(rest) = value_token.strip_prefix("0o")
-                    && rest.chars().all(|c| c.is_ascii_digit() && c < '8')
-                {
-                    let value_offset = line_offset + line.find(value_token).unwrap_or(0);
+            // Skip if empty or quoted
+            if trimmed.is_empty()
+                || trimmed.starts_with('"')
+                || trimmed.starts_with('\'')
+                || trimmed.starts_with('[')
+                || trimmed.starts_with('{')
+            {
+                continue;
+            }
+
+            // Byte offset of `trimmed` within `line`
+            let trim_offset_in_line = part_start_in_line + (part.len() - part.trim_start().len());
+
+            // Extract the value token (before any space)
+            let value_token = trimmed.split_whitespace().next().unwrap_or(trimmed);
+
+            // Check for explicit octal (0o prefix)
+            if forbid_explicit
+                && value_token.starts_with("0o")
+                && let Some(rest) = value_token.strip_prefix("0o")
+                && rest.chars().all(|c| c.is_ascii_digit() && c < '8')
+            {
+                let value_offset = line_offset + trim_offset_in_line;
+                let col = trim_offset_in_line + 1;
+                let severity = config.get_effective_severity(self.code(), self.default_severity());
+                let span = Span::new(
+                    Location::new(line_num, col, value_offset),
+                    Location::new(
+                        line_num,
+                        col + value_token.len(),
+                        value_offset + value_token.len(),
+                    ),
+                );
+                diagnostics.push(
+                    DiagnosticBuilder::new(
+                        self.code(),
+                        severity,
+                        format!(
+                            "found explicit octal value '{value_token}' (use quoted string to avoid ambiguity)"
+                        ),
+                        span,
+                    )
+                    .build_with_context(context.source_context()),
+                );
+            }
+
+            // Check for implicit octal (leading zero followed by octal digits)
+            if forbid_implicit
+                && value_token.starts_with('0')
+                && value_token.len() > 1
+                && !value_token.starts_with("0o")
+                && !value_token.starts_with("0x")
+            {
+                let rest = &value_token[1..];
+                if !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit() && c < '8') {
+                    let value_offset = line_offset + trim_offset_in_line;
+                    let col = trim_offset_in_line + 1;
                     let severity =
                         config.get_effective_severity(self.code(), self.default_severity());
-
-                    let location = Location::new(line_num, 1, value_offset);
                     let span = Span::new(
-                        location,
-                        Location::new(line_num, 1, value_offset + value_token.len()),
+                        Location::new(line_num, col, value_offset),
+                        Location::new(
+                            line_num,
+                            col + value_token.len(),
+                            value_offset + value_token.len(),
+                        ),
                     );
-
                     diagnostics.push(
                         DiagnosticBuilder::new(
                             self.code(),
                             severity,
                             format!(
-                                "found explicit octal value '{value_token}' (use quoted string to avoid ambiguity)"
+                                "found implicit octal value '{value_token}' (use quoted string or explicit '0o' prefix)"
                             ),
                             span,
                         )
                         .build_with_context(context.source_context()),
                     );
                 }
-
-                // Check for implicit octal (leading zero followed by digits)
-                if forbid_implicit
-                    && value_token.starts_with('0')
-                    && value_token.len() > 1
-                    && !value_token.starts_with("0o")
-                    && !value_token.starts_with("0x")
-                {
-                    // Check if all chars after '0' are octal digits
-                    let rest = &value_token[1..];
-                    if !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit() && c < '8') {
-                        let value_offset = line_offset + line.find(value_token).unwrap_or(0);
-                        let severity =
-                            config.get_effective_severity(self.code(), self.default_severity());
-
-                        let location = Location::new(line_num, 1, value_offset);
-                        let span = Span::new(
-                            location,
-                            Location::new(line_num, 1, value_offset + value_token.len()),
-                        );
-
-                        diagnostics.push(
-                            DiagnosticBuilder::new(
-                                self.code(),
-                                severity,
-                                format!(
-                                    "found implicit octal value '{value_token}' (use quoted string or explicit '0o' prefix)"
-                                ),
-                                span,
-                            )
-                            .build_with_context(context.source_context()),
-                        );
-                    }
-                }
             }
         }
-
-        diagnostics
     }
 }
 
@@ -345,5 +396,93 @@ mod tests {
         let lint_context = LintContext::new(yaml);
         let diagnostics = rule.check(&lint_context, &value, &config);
         assert_eq!(diagnostics.len(), 2);
+    }
+
+    // Regression tests for issue #176: false positive on octal patterns in comments.
+
+    #[test]
+    fn test_octal_values_no_false_positive_in_comment_line() {
+        // A pure comment line containing 0o755 must not trigger a diagnostic.
+        let yaml = "# permissions: 0o755 is octal\nmode: 7";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = OctalValuesRule;
+        let config = LintConfig::default();
+
+        let lint_context = LintContext::new(yaml);
+        let diagnostics = rule.check(&lint_context, &value, &config);
+        assert!(
+            diagnostics.is_empty(),
+            "expected no diagnostics for octal pattern in comment line, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn test_octal_values_no_false_positive_in_inline_comment() {
+        // An inline comment after a valid value must not trigger a diagnostic.
+        let yaml = "mode: 7 # was 0o755 before";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = OctalValuesRule;
+        let config = LintConfig::default();
+
+        let lint_context = LintContext::new(yaml);
+        let diagnostics = rule.check(&lint_context, &value, &config);
+        assert!(
+            diagnostics.is_empty(),
+            "expected no diagnostics for octal pattern in inline comment, got: {diagnostics:?}"
+        );
+    }
+
+    // Regression tests for issue #177: diagnostic position must point to the value, not the key.
+
+    #[test]
+    fn test_octal_values_explicit_correct_position() {
+        // "mode: 0o755" — the value '0o755' starts at column 7 (1-indexed), offset 6.
+        let yaml = "mode: 0o755";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = OctalValuesRule;
+        let config = LintConfig::default();
+
+        let lint_context = LintContext::new(yaml);
+        let diagnostics = rule.check(&lint_context, &value, &config);
+        assert!(!diagnostics.is_empty(), "expected a diagnostic for 0o755");
+        let span = diagnostics[0].span;
+        assert_eq!(
+            span.start.column, 7,
+            "expected column 7 for octal value, got {}",
+            span.start.column
+        );
+        assert_eq!(
+            span.start.offset, 6,
+            "expected offset 6 for octal value, got {}",
+            span.start.offset
+        );
+    }
+
+    #[test]
+    fn test_octal_values_implicit_correct_position() {
+        // "perm: 0755" — the value '0755' starts at column 7 (1-indexed), offset 6.
+        let yaml = "perm: 0755";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = OctalValuesRule;
+        let config = LintConfig::default();
+
+        let lint_context = LintContext::new(yaml);
+        let diagnostics = rule.check(&lint_context, &value, &config);
+        assert!(!diagnostics.is_empty(), "expected a diagnostic for 0755");
+        let span = diagnostics[0].span;
+        assert_eq!(
+            span.start.column, 7,
+            "expected column 7 for octal value, got {}",
+            span.start.column
+        );
+        assert_eq!(
+            span.start.offset, 6,
+            "expected offset 6 for octal value, got {}",
+            span.start.offset
+        );
     }
 }

--- a/crates/fast-yaml-linter/src/rules/quoted_strings.rs
+++ b/crates/fast-yaml-linter/src/rules/quoted_strings.rs
@@ -215,7 +215,10 @@ impl QuotedStringsRule {
                 }
 
                 if required == "only-when-needed" {
-                    let needs = Self::needs_quotes(value)
+                    let has_escape =
+                        style == ScalarStyle::DoubleQuoted && Self::has_yaml_escape(value);
+                    let needs = has_escape
+                        || Self::needs_quotes(value)
                         || extra_required.iter().any(|p| value.contains(p.as_str()));
                     if !needs {
                         let severity =
@@ -280,6 +283,24 @@ impl QuotedStringsRule {
             Location::new(line, col + 1, offset),
             Location::new(line, col + 1 + len, offset + len),
         )
+    }
+
+    /// Returns `true` if a double-quoted scalar's decoded value indicates it required escape
+    /// sequences in the source.
+    ///
+    /// Saphyr provides the already-decoded scalar value. A double-quoted string that contained
+    /// YAML escape sequences (`\n`, `\t`, `\r`, `\\`, `\"`, `\uXXXX`, etc.) will decode to
+    /// a string that either contains a backslash (from `\\`) or contains control characters
+    /// (from `\n`, `\t`, etc.). In either case, removing the quotes would produce a different
+    /// value, so the quotes are necessary.
+    fn has_yaml_escape(value: &str) -> bool {
+        value.contains('\\')
+            || value.chars().any(|c| {
+                matches!(
+                    c,
+                    '\n' | '\r' | '\t' | '\x00' | '\x07' | '\x08' | '\x0C' | '\x0B' | '\x1B'
+                )
+            })
     }
 
     /// Checks if a string needs quotes based on YAML syntax rules.
@@ -525,6 +546,57 @@ mod tests {
 
         assert!(!QuotedStringsRule::needs_quotes("simple"));
         assert!(!QuotedStringsRule::needs_quotes("hello_world"));
+    }
+
+    // Regression tests for issue #175: false positive on double-quoted strings with escapes.
+
+    #[test]
+    fn test_no_false_positive_escape_newline() {
+        // "\n" is a newline escape — removing quotes would produce a literal 'n', not a newline.
+        let yaml = "message: \"line1\\nline2\"";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = QuotedStringsRule;
+        let config = LintConfig::default();
+
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &config);
+        assert!(
+            diagnostics.is_empty(),
+            "expected no diagnostics for double-quoted string with \\n escape, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn test_no_false_positive_escape_tab() {
+        let yaml = "data: \"col1\\tcol2\"";
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = QuotedStringsRule;
+        let config = LintConfig::default();
+
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &config);
+        assert!(
+            diagnostics.is_empty(),
+            "expected no diagnostics for double-quoted string with \\t escape, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn test_no_false_positive_escape_backslash() {
+        let yaml = r#"path: "C:\\Users\\foo""#;
+        let value = Parser::parse_str(yaml).unwrap().unwrap();
+
+        let rule = QuotedStringsRule;
+        let config = LintConfig::default();
+
+        let context = LintContext::new(yaml);
+        let diagnostics = rule.check(&context, &value, &config);
+        assert!(
+            diagnostics.is_empty(),
+            "expected no diagnostics for double-quoted string with \\\\ escape, got: {diagnostics:?}"
+        );
     }
 
     // Regression tests for issue #113: false positives on quotes inside plain scalars.


### PR DESCRIPTION
## Summary

- `quoted-strings`: suppress "does not need quotes" for double-quoted strings containing YAML escape sequences (`\n`, `\t`, `\\`, `\"`, `\uXXXX`, etc.) — removing quotes silently corrupts the parsed value
- `octal-values`: skip octal pattern matches inside comment lines and inline comments to eliminate false positives in documented YAML files
- `octal-values`: report diagnostic at the octal value token position instead of column 1 of the mapping key

Fixes #175, #176, #177.

## Test plan

- [ ] `cargo nextest run -p fast-yaml-linter` — all 1049 tests pass
- [ ] `cargo clippy` — no warnings
- [ ] `cargo +nightly fmt --check` — no formatting changes
- [ ] Regression tests added for each bug (3 for #175, 2 for #176, 2 for #177)