### PR TITLE
fix(cli): valid JSON output for multi-file lint and suppress empty summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(linter): `quoted-strings` rule no longer emits "does not need quotes" for double-quoted strings with `\uXXXX`, `\UXXXXXXXX`, or `\xXX` escape sequences; these escapes decode to characters indistinguishable from plain text, requiring raw source inspection (#182)
 - fix(linter): `truthy` rule now distinguishes non-standard YAML 1.1-only values (`yes`, `no`, `on`, `off`, `y`, `n`) from non-canonical YAML 1.2.2 booleans (`True`, `TRUE`, `False`, `FALSE`); the latter now emit "non-canonical boolean, use 'true' or 'false'" instead of "non-standard truthy value" (#181)
 - fix(cli): `fy lint` now returns an error when `--in-place` / `-i` is passed instead of silently accepting a flag with no effect (#180)
+- fix(cli): `fy lint --format json` on multiple files/directories now emits a single valid JSON array where each entry includes a `file` field; previously the output interleaved plain-text path headers between per-file JSON arrays, making it unparseable (#185)
+- fix(cli): `fy lint` text formatter no longer prints a `0 errors, 0 warnings` summary when there are no diagnostics; quiet mode (`--quiet`) now produces no output when there are no errors (#186)
 - fix(linter): `quoted-strings` rule no longer emits "does not need quotes" for double-quoted strings that contain YAML escape sequences (`\n`, `\t`, `\\`, `\"`, `\uXXXX`, etc.); removing quotes would silently corrupt the value (#175)
 - fix(linter): `octal-values` rule no longer fires on octal patterns (`0o\d+`, `0\d+`) found inside YAML comment lines or inline comments (#176)
 - fix(linter): `octal-values` diagnostic position now points to the octal value token, not to column 1 of the mapping key (#177)

--- a/crates/fast-yaml-cli/src/commands/lint_batch.rs
+++ b/crates/fast-yaml-cli/src/commands/lint_batch.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use fast_yaml_linter::{Formatter, JsonFormatter, LintConfig, Linter, Severity, TextFormatter};
+use fast_yaml_linter::{Diagnostic, Formatter, LintConfig, Linter, Severity, TextFormatter};
 use rayon::prelude::*;
 
 use crate::cli::LintFormat;
@@ -79,16 +79,17 @@ pub fn execute_lint_batch(config: &LintBatchConfig, paths: &[PathBuf]) -> Result
 
     let file_paths: Vec<PathBuf> = files.iter().map(|f| f.path.clone()).collect();
 
-    // Process files in parallel, collecting (path, output, has_errors) tuples
-    let results: Vec<(PathBuf, String, bool)> = pool.install(|| {
+    // Process files in parallel, collecting (path, content, diagnostics, has_errors) tuples.
+    // Read/lint errors are printed to stderr directly; has_errors=true is set in that case.
+    let results: Vec<(PathBuf, String, Vec<Diagnostic>, bool)> = pool.install(|| {
         file_paths
             .par_iter()
             .map(|path| {
                 let content = match std::fs::read_to_string(path) {
                     Ok(c) => c,
                     Err(e) => {
-                        let msg = format!("error: failed to read '{}': {e}\n", path.display());
-                        return (path.clone(), msg, true);
+                        eprintln!("error: failed to read '{}': {e}", path.display());
+                        return (path.clone(), String::new(), vec![], true);
                     }
                 };
 
@@ -96,8 +97,8 @@ pub fn execute_lint_batch(config: &LintBatchConfig, paths: &[PathBuf]) -> Result
                 let diagnostics = match linter.lint(&content) {
                     Ok(d) => d,
                     Err(e) => {
-                        let msg = format!("error: '{}': {e}\n", path.display());
-                        return (path.clone(), msg, true);
+                        eprintln!("error: '{}': {e}", path.display());
+                        return (path.clone(), content, vec![], true);
                     }
                 };
 
@@ -111,38 +112,45 @@ pub fn execute_lint_batch(config: &LintBatchConfig, paths: &[PathBuf]) -> Result
                 };
 
                 let has_errors = filtered.iter().any(|d| d.severity == Severity::Error);
-
-                let output = match format {
-                    LintFormat::Text => {
-                        let mut formatter = TextFormatter::new();
-                        formatter.use_color = use_color;
-                        formatter.format(&filtered, &content)
-                    }
-                    LintFormat::Json => {
-                        let formatter = JsonFormatter::new(true);
-                        formatter.format(&filtered, &content)
-                    }
-                };
-
-                // Prefix output with the file path when linting multiple files
-                let prefixed = if output.is_empty() {
-                    output
-                } else {
-                    format!("{}:\n{}", path.display(), output)
-                };
-
-                (path.clone(), prefixed, has_errors)
+                (path.clone(), content, filtered, has_errors)
             })
             .collect()
     });
 
-    let mut any_errors = false;
-    for (_path, output, has_errors) in &results {
-        if !output.is_empty() {
-            print!("{output}");
+    let any_errors = results.iter().any(|(_, _, _, has_errors)| *has_errors);
+
+    match format {
+        LintFormat::Text => {
+            for (path, content, diagnostics, _) in &results {
+                if diagnostics.is_empty() {
+                    continue;
+                }
+                let mut formatter = TextFormatter::new();
+                formatter.use_color = use_color;
+                let output = formatter.format(diagnostics, content);
+                if !output.is_empty() {
+                    println!("{}:", path.display());
+                    print!("{output}");
+                }
+            }
         }
-        if *has_errors {
-            any_errors = true;
+        LintFormat::Json => {
+            // Collect all diagnostics into a single JSON array with a `file` field.
+            let all: Vec<serde_json::Value> = results
+                .iter()
+                .flat_map(|(path, _, diagnostics, _)| {
+                    let file = path.display().to_string();
+                    diagnostics.iter().map(move |d| {
+                        let mut v = serde_json::to_value(d).unwrap_or(serde_json::Value::Null);
+                        if let serde_json::Value::Object(ref mut map) = v {
+                            map.insert("file".to_string(), serde_json::Value::String(file.clone()));
+                        }
+                        v
+                    })
+                })
+                .collect();
+            let json = serde_json::to_string_pretty(&all).unwrap_or_else(|_| "[]".to_string());
+            println!("{json}");
         }
     }
 

--- a/crates/fast-yaml-cli/tests/integration_tests.rs
+++ b/crates/fast-yaml-cli/tests/integration_tests.rs
@@ -469,6 +469,7 @@ fn test_lint_valid_yaml() {
 fn test_lint_with_warnings() {
     let long_line = "name: this is a very very very very very very very very very very very very very very very very very very very very long line";
 
+    // line-length rule emits info-severity diagnostics.
     Command::cargo_bin("fy")
         .unwrap()
         .arg("lint")
@@ -478,7 +479,7 @@ fn test_lint_with_warnings() {
         .assert()
         .success()
         .code(0)
-        .stdout(predicate::str::contains("warning"));
+        .stdout(predicate::str::contains("line-length"));
 }
 
 #[test]
@@ -524,6 +525,7 @@ fn test_lint_with_indent_size_option() {
 #[test]
 #[cfg(feature = "linter")]
 fn test_lint_text_format() {
+    // Clean YAML produces no diagnostics — stdout must be empty.
     Command::cargo_bin("fy")
         .unwrap()
         .arg("lint")
@@ -533,7 +535,7 @@ fn test_lint_text_format() {
         .assert()
         .success()
         .code(0)
-        .stdout(predicate::str::contains("errors"));
+        .stdout(predicate::str::is_empty());
 }
 
 #[test]
@@ -595,6 +597,7 @@ fn test_lint_file_input() {
 #[test]
 #[cfg(feature = "linter")]
 fn test_lint_trailing_whitespace() {
+    // trailing-whitespace rule emits hint-severity diagnostics.
     Command::cargo_bin("fy")
         .unwrap()
         .arg("lint")
@@ -602,7 +605,7 @@ fn test_lint_trailing_whitespace() {
         .assert()
         .success()
         .code(0)
-        .stdout(predicate::str::contains("warning"));
+        .stdout(predicate::str::contains("trailing-whitespace"));
 }
 
 // =============================================================================

--- a/crates/fast-yaml-linter/src/formatter/text.rs
+++ b/crates/fast-yaml-linter/src/formatter/text.rs
@@ -15,7 +15,7 @@ use std::fmt::Write;
 ///
 /// let formatter = TextFormatter::new();
 /// let output = formatter.format(&[], "");
-/// assert!(output.contains("0 errors"));
+/// assert!(output.is_empty());
 /// ```
 pub struct TextFormatter {
     /// Show source context.
@@ -193,13 +193,9 @@ impl Formatter for TextFormatter {
             .filter(|d| d.severity == Severity::Warning)
             .count();
 
-        let summary = if error_count > 0 || warning_count > 0 {
-            format!("{error_count} errors, {warning_count} warnings")
-        } else {
-            "0 errors, 0 warnings".to_string()
-        };
-
-        writeln!(output, "{summary}").unwrap();
+        if error_count > 0 || warning_count > 0 {
+            writeln!(output, "{error_count} errors, {warning_count} warnings").unwrap();
+        }
 
         output
     }
@@ -227,7 +223,7 @@ mod tests {
     fn test_formatter_empty() {
         let formatter = TextFormatter::new();
         let output = formatter.format(&[], "");
-        assert!(output.contains("0 errors, 0 warnings"));
+        assert!(output.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `fy lint --format json` on multiple files/directories now emits a single valid JSON array where each entry contains a `file` field; previously the output interleaved plain-text path headers between per-file JSON arrays, making it unparseable by any JSON tool. Closes #185
- `TextFormatter` no longer appends `0 errors, 0 warnings` when there are no diagnostics; `fy lint --quiet` now produces no output when there are no errors. Closes #186

## Changes

- `crates/fast-yaml-linter/src/formatter/text.rs`: only print summary when `error_count > 0 || warning_count > 0`
- `crates/fast-yaml-cli/src/commands/lint_batch.rs`: for JSON format, collect all diagnostics across files and serialize as a single array with `file` field; for text format, prefix each file's output with its path
- `crates/fast-yaml-cli/tests/integration_tests.rs`: update 3 tests that incorrectly relied on the always-present summary string

## Test plan

- [x] `cargo nextest run --workspace --exclude fast-yaml --exclude fast-yaml-nodejs` — 1051 passed
- [x] `cargo clippy ... -- -D warnings` — clean
- [x] `cargo +nightly fmt --check` — clean
- [x] `cargo deny check` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc ...` — clean