### PR TITLE
fix(linter): wire require_document_start/end into rule check logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix(linter): `LintConfig.require_document_start` and `require_document_end` are now wired into `DocumentStartRule` and `DocumentEndRule` respectively; previously these fields were dead and had no effect — setting them to `true` now correctly requires `---`/`...` markers. Added `with_require_document_start` and `with_require_document_end` builder methods to `LintConfig`. (#193)
 - `duplicate-key` rule: fix false negative when mapping contains merge-key alias (`<<: *anchor`) — keys after the alias were silently skipped due to `Event::Alias` not advancing the key-tracking state (fixes #188)
 - `colons` rule: fix false positive when block mapping key has trailing whitespace but no inline value — spaces after `:` are now only checked when a non-whitespace value follows on the same line (fixes #190)
 - fix(linter): `quoted-strings` rule no longer emits "does not need quotes" for double-quoted strings with `\uXXXX`, `\UXXXXXXXX`, or `\xXX` escape sequences; these escapes decode to characters indistinguishable from plain text, requiring raw source inspection (#182)

--- a/crates/fast-yaml-linter/src/linter.rs
+++ b/crates/fast-yaml-linter/src/linter.rs
@@ -199,6 +199,46 @@ impl LintConfig {
             .unwrap_or(default)
     }
 
+    /// Sets whether the document start marker (`---`) is required.
+    ///
+    /// When `true`, the linter will warn if a document is missing `---`.
+    /// This is equivalent to setting `present: "required"` via `rule_configs` for
+    /// the `document-start` rule, but `rule_configs` takes priority if both are set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fast_yaml_linter::LintConfig;
+    ///
+    /// let config = LintConfig::new().with_require_document_start(true);
+    /// assert!(config.require_document_start);
+    /// ```
+    #[must_use]
+    pub const fn with_require_document_start(mut self, require: bool) -> Self {
+        self.require_document_start = require;
+        self
+    }
+
+    /// Sets whether the document end marker (`...`) is required.
+    ///
+    /// When `true`, the linter will warn if a document is missing `...`.
+    /// This is equivalent to setting `present: true` via `rule_configs` for
+    /// the `document-end` rule, but `rule_configs` takes priority if both are set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fast_yaml_linter::LintConfig;
+    ///
+    /// let config = LintConfig::new().with_require_document_end(true);
+    /// assert!(config.require_document_end);
+    /// ```
+    #[must_use]
+    pub const fn with_require_document_end(mut self, require: bool) -> Self {
+        self.require_document_end = require;
+        self
+    }
+
     /// Allows or disallows duplicate keys.
     ///
     /// # Examples
@@ -683,6 +723,82 @@ mod tests {
                 .iter()
                 .any(|d| d.code.as_str() == crate::DiagnosticCode::EMPTY_VALUES),
             "single-doc without empty values should produce no empty-values diagnostics"
+        );
+    }
+
+    #[test]
+    fn test_require_document_start_missing() {
+        let yaml = "key: value\n";
+        let config = LintConfig::new().with_require_document_start(true);
+        let linter = Linter::with_all_rules_and_config(config);
+        let diagnostics = linter.lint(yaml).unwrap();
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.code.as_str() == crate::DiagnosticCode::DOCUMENT_START),
+            "require_document_start=true must produce a diagnostic when '---' is absent"
+        );
+    }
+
+    #[test]
+    fn test_require_document_start_present() {
+        let yaml = "---\nkey: value\n";
+        let config = LintConfig::new().with_require_document_start(true);
+        let linter = Linter::with_all_rules_and_config(config);
+        let diagnostics = linter.lint(yaml).unwrap();
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.code.as_str() == crate::DiagnosticCode::DOCUMENT_START),
+            "require_document_start=true must not produce a diagnostic when '---' is present"
+        );
+    }
+
+    #[test]
+    fn test_require_document_end_missing() {
+        let yaml = "key: value\n";
+        let config = LintConfig::new().with_require_document_end(true);
+        let linter = Linter::with_all_rules_and_config(config);
+        let diagnostics = linter.lint(yaml).unwrap();
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.code.as_str() == crate::DiagnosticCode::DOCUMENT_END),
+            "require_document_end=true must produce a diagnostic when '...' is absent"
+        );
+    }
+
+    #[test]
+    fn test_require_document_end_present() {
+        let yaml = "key: value\n...\n";
+        let config = LintConfig::new().with_require_document_end(true);
+        let linter = Linter::with_all_rules_and_config(config);
+        let diagnostics = linter.lint(yaml).unwrap();
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.code.as_str() == crate::DiagnosticCode::DOCUMENT_END),
+            "require_document_end=true must not produce a diagnostic when '...' is present"
+        );
+    }
+
+    #[test]
+    fn test_rule_config_overrides_require_document_start() {
+        // rule_configs with present="forbidden" should override require_document_start=true
+        let yaml = "---\nkey: value\n";
+        let config = LintConfig::new()
+            .with_require_document_start(true)
+            .with_rule_config(
+                crate::DiagnosticCode::DOCUMENT_START,
+                crate::config::RuleConfig::new().with_option("present", "forbidden"),
+            );
+        let linter = Linter::with_all_rules_and_config(config);
+        let diagnostics = linter.lint(yaml).unwrap();
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.code.as_str() == crate::DiagnosticCode::DOCUMENT_START),
+            "rule_config present=forbidden should override require_document_start and flag existing '---'"
         );
     }
 

--- a/crates/fast-yaml-linter/src/rules/document_end.rs
+++ b/crates/fast-yaml-linter/src/rules/document_end.rs
@@ -52,7 +52,7 @@ impl super::LintRule for DocumentEndRule {
         let required = config
             .get_rule_config(self.code())
             .and_then(|rc| rc.options.get_bool("present"))
-            .unwrap_or(false);
+            .unwrap_or(config.require_document_end);
 
         if !required {
             return Vec::new();

--- a/crates/fast-yaml-linter/src/rules/document_start.rs
+++ b/crates/fast-yaml-linter/src/rules/document_start.rs
@@ -52,7 +52,11 @@ impl super::LintRule for DocumentStartRule {
         let presence = config
             .get_rule_config(self.code())
             .and_then(|rc| rc.options.get_string("present"))
-            .unwrap_or("allowed");
+            .unwrap_or(if config.require_document_start {
+                "required"
+            } else {
+                "allowed"
+            });
 
         let source_context = context.source_context();
         match presence {


### PR DESCRIPTION
Closes #193

## Summary

- `LintConfig.require_document_start` and `require_document_end` were dead fields — reading them had no effect on linting behavior
- `DocumentStartRule` now uses `require_document_start` as the fallback default (equivalent to `present: "required"`) when no `rule_configs` override is present
- `DocumentEndRule` now uses `require_document_end` as the fallback default (equivalent to `present: true`) when no `rule_configs` override is present
- `rule_configs` options continue to take priority over top-level fields
- Added `with_require_document_start` and `with_require_document_end` builder methods to `LintConfig`

## Test plan

- [ ] `test_require_document_start_missing` — verifies diagnostic is emitted when `---` absent and `require_document_start=true`
- [ ] `test_require_document_start_present` — verifies no diagnostic when `---` present and `require_document_start=true`
- [ ] `test_require_document_end_missing` — verifies diagnostic is emitted when `...` absent and `require_document_end=true`
- [ ] `test_require_document_end_present` — verifies no diagnostic when `...` present and `require_document_end=true`
- [ ] `test_rule_config_overrides_require_document_start` — verifies `rule_configs` takes priority over top-level field
- [ ] All 1062 existing tests pass