### PR TITLE
fix(python): enforce ParallelConfig.max_documents limit in parse/dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - fix(linter): `LintConfig.require_document_start` and `require_document_end` are now wired into `DocumentStartRule` and `DocumentEndRule` respectively; previously these fields were dead and had no effect — setting them to `true` now correctly requires `---`/`...` markers. Added `with_require_document_start` and `with_require_document_end` builder methods to `LintConfig`. (#193)
+- fix(python): `ParallelConfig.max_documents` is now enforced — `parse_parallel` and `dump_parallel` return `ValueError` when the parsed document count exceeds the configured limit; previously the limit was validated on construction but silently ignored during parsing (#195)
 - `duplicate-key` rule: fix false negative when mapping contains merge-key alias (`<<: *anchor`) — keys after the alias were silently skipped due to `Event::Alias` not advancing the key-tracking state (fixes #188)
 - `colons` rule: fix false positive when block mapping key has trailing whitespace but no inline value — spaces after `:` are now only checked when a non-whitespace value follows on the same line (fixes #190)
 - fix(linter): `quoted-strings` rule no longer emits "does not need quotes" for double-quoted strings with `\uXXXX`, `\UXXXXXXXX`, or `\xXX` escape sequences; these escapes decode to characters indistinguishable from plain text, requiring raw source inspection (#182)

--- a/python/src/parallel.rs
+++ b/python/src/parallel.rs
@@ -44,6 +44,7 @@ const ABSOLUTE_MAX_DOCUMENTS: usize = 10_000_000;
 pub struct PyParallelConfig {
     inner: RustParallelConfig,
     auto_tune: bool,
+    max_documents: usize,
 }
 
 #[pymethods]
@@ -105,13 +106,13 @@ impl PyParallelConfig {
             .with_sequential_threshold(min_chunk_size)
             .with_max_input_size(max_input_size);
 
-        // Note: max_chunk_size and max_documents are validated but not stored in new Config API
-        // They are used for FFI validation only
-        let _ = (max_chunk_size, max_documents); // Prevent unused variable warnings
+        // Note: max_chunk_size is validated but not stored in new Config API
+        let _ = max_chunk_size;
 
         Ok(Self {
             inner: config,
             auto_tune,
+            max_documents,
         })
     }
 
@@ -134,6 +135,7 @@ impl PyParallelConfig {
         Ok(Self {
             inner: self.inner.clone().with_workers(count),
             auto_tune: self.auto_tune,
+            max_documents: self.max_documents,
         })
     }
 
@@ -152,6 +154,7 @@ impl PyParallelConfig {
         Ok(Self {
             inner: self.inner.clone().with_max_input_size(size),
             auto_tune: self.auto_tune,
+            max_documents: self.max_documents,
         })
     }
 
@@ -167,11 +170,10 @@ impl PyParallelConfig {
                 "max_documents must be between 1 and {ABSOLUTE_MAX_DOCUMENTS} (10M)"
             )));
         }
-        // Note: max_documents is validated but not stored in new Config API
-        // Validation happens at FFI boundary for security
         Ok(Self {
             inner: self.inner.clone(),
             auto_tune: self.auto_tune,
+            max_documents: count,
         })
     }
 
@@ -190,6 +192,7 @@ impl PyParallelConfig {
         Ok(Self {
             inner: self.inner.clone().with_sequential_threshold(size),
             auto_tune: self.auto_tune,
+            max_documents: self.max_documents,
         })
     }
 
@@ -206,10 +209,10 @@ impl PyParallelConfig {
             ));
         }
         // Note: max_chunk_size is validated but not stored in new Config API
-        // Validation happens at FFI boundary for security
         Ok(Self {
             inner: self.inner.clone(),
             auto_tune: self.auto_tune,
+            max_documents: self.max_documents,
         })
     }
 
@@ -223,6 +226,7 @@ impl PyParallelConfig {
         Self {
             inner: self.inner.clone(),
             auto_tune: enabled,
+            max_documents: self.max_documents,
         }
     }
 
@@ -286,6 +290,9 @@ fn parse_parallel(
     source: &str,
     config: Option<PyParallelConfig>,
 ) -> PyResult<Py<PyAny>> {
+    // Capture max_documents before releasing GIL
+    let max_documents = config.as_ref().map(|cfg| cfg.max_documents);
+
     // Release GIL for parallel processing
     let result = py.detach(|| match config {
         Some(cfg) => parse_parallel_with_config(source, &cfg.inner),
@@ -293,6 +300,18 @@ fn parse_parallel(
     });
 
     let values = result.map_err(|e: ParallelError| PyValueError::new_err(e.to_string()))?;
+
+    // Enforce document count limit
+    if let Some(limit) = max_documents {
+        if values.len() > limit {
+            return Err(PyValueError::new_err(format!(
+                "document count {} exceeds max_documents limit {}. Consider increasing \
+                 max_documents or processing in batches.",
+                values.len(),
+                limit
+            )));
+        }
+    }
 
     // Convert Vec<Value> to Python list with pre-allocated capacity
     let mut py_values = Vec::with_capacity(values.len());
@@ -365,11 +384,11 @@ fn dump_parallel(
     }
 
     // Validate against config limits
-    // Note: max_documents is no longer in Config API, so we use a hardcoded limit
-    let max_docs = 100_000; // Default limit
+    let max_docs = config.map_or(100_000, |cfg| cfg.max_documents);
     if yaml_values.len() > max_docs {
         return Err(PyValueError::new_err(format!(
-            "document count {} exceeds maximum {}. Consider processing in batches.",
+            "document count {} exceeds max_documents limit {}. Consider increasing \
+             max_documents or processing in batches.",
             yaml_values.len(),
             max_docs
         )));


### PR DESCRIPTION
## Summary

- `PyParallelConfig` now stores `max_documents` as a field instead of discarding it after validation
- `parse_parallel` checks the parsed document count against the limit and raises `ValueError` if exceeded
- `dump_parallel` uses the configured limit instead of a hardcoded `100_000` default
- All builder methods (`with_max_documents`, `with_thread_count`, etc.) propagate the field

## Test plan

- [ ] Verify `parse_parallel` raises `ValueError` when document count exceeds `max_documents`
- [ ] Verify `dump_parallel` raises `ValueError` when document count exceeds `max_documents`
- [ ] Verify default behavior (no config) is unchanged
- [ ] Run `cargo nextest run --workspace --exclude fast-yaml --exclude fast-yaml-nodejs`

Fixes #195