### PR TITLE
fix(cli): detect YAML comments in format and require --strip-comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(cli): `fy format` now exits with an error (exit code 1) when the input contains YAML comments, which are silently stripped by the formatter. Pass `--strip-comments` to acknowledge comment loss and proceed. Previously, comments were dropped without any warning or error. (#199)
+
+### Added
+
+- **CLI**: `--strip-comments` flag on `fy format` — suppress the new comment-detection error and allow formatting to proceed (comments will still be stripped from the output). (#199)
+
 ## [0.6.0] - 2026-03-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ const yamlStr = safeDump(data);
 ```bash
 # Single file operations
 fy parse config.yaml           # Validate syntax
-fy format -i config.yaml       # Format in-place
+fy format -i config.yaml       # Format in-place (exits with error if comments detected)
+fy format -i --strip-comments config.yaml  # Format and strip comments silently
 fy convert json config.yaml    # YAML → JSON
 fy lint config.yaml            # Lint with diagnostics
 
@@ -132,6 +133,9 @@ fy lint --exclude "tests/**" . # Lint all except tests
 
 > [!TIP]
 > Batch mode activates automatically for directories, globs, or multiple files. Supports parallel processing, include/exclude patterns, and respects `.gitignore`.
+
+> [!WARNING]
+> `fy format` does **not** preserve YAML comments. If the input contains comments, the command exits with an error (exit code 1). Pass `--strip-comments` to acknowledge this and allow formatting to proceed — comments will be removed from the output.
 
 ## Features
 

--- a/crates/fast-yaml-cli/src/cli.rs
+++ b/crates/fast-yaml-cli/src/cli.rs
@@ -90,6 +90,12 @@ pub enum Command {
         /// Show what would be changed without modifying files
         #[arg(short = 'n', long)]
         dry_run: bool,
+
+        /// Suppress the error when YAML comments are detected.
+        /// Comments are not preserved by the formatter and will be stripped.
+        /// Without this flag, formatting a file that contains comments exits with an error.
+        #[arg(long)]
+        strip_comments: bool,
     },
 
     /// Convert between YAML and JSON

--- a/crates/fast-yaml-cli/src/commands/format.rs
+++ b/crates/fast-yaml-cli/src/commands/format.rs
@@ -7,29 +7,58 @@ use crate::io::{InputSource, OutputWriter};
 /// Format command implementation
 pub struct FormatCommand {
     config: CommonConfig,
+    strip_comments: bool,
 }
 
 impl FormatCommand {
-    pub const fn new(config: CommonConfig) -> Self {
-        Self { config }
+    pub const fn new(config: CommonConfig, strip_comments: bool) -> Self {
+        Self {
+            config,
+            strip_comments,
+        }
     }
 
     /// Execute format command
     pub fn execute(&self, input: &InputSource, output: &OutputWriter) -> Result<()> {
-        // Create emitter config from formatter settings
+        if !self.strip_comments && yaml_has_comments(input.as_str()) {
+            anyhow::bail!(
+                "warning: YAML comments will be stripped by the formatter. \
+                 Use --strip-comments to suppress this error."
+            );
+        }
+
         let emitter_config = EmitterConfig::new()
             .with_indent(self.config.formatter.indent() as usize)
             .with_width(self.config.formatter.width());
 
-        // Use format_with_config which automatically selects streaming for large files
         let formatted = Emitter::format_with_config(input.as_str(), &emitter_config)
             .context("Failed to format YAML")?;
 
-        // Write output
         output.write(&formatted)?;
 
         Ok(())
     }
+}
+
+/// Returns true if the YAML input contains at least one comment.
+///
+/// Scans line by line and tracks single-quoted and double-quoted string regions
+/// to avoid false positives from `#` inside string literals.
+fn yaml_has_comments(input: &str) -> bool {
+    for line in input.lines() {
+        let mut in_single = false;
+        let mut in_double = false;
+
+        for (_, ch) in line.char_indices() {
+            match ch {
+                '\'' if !in_double => in_single = !in_single,
+                '"' if !in_single => in_double = !in_double,
+                '#' if !in_single && !in_double => return true,
+                _ => {}
+            }
+        }
+    }
+    false
 }
 
 #[cfg(test)]
@@ -38,6 +67,12 @@ mod tests {
     use crate::config::FormatterConfig;
     use crate::io::input::InputOrigin;
     use tempfile::NamedTempFile;
+
+    fn make_cmd(strip_comments: bool) -> FormatCommand {
+        let config = CommonConfig::new()
+            .with_formatter(FormatterConfig::new().with_indent(2).with_width(80));
+        FormatCommand::new(config, strip_comments)
+    }
 
     #[test]
     fn test_format_simple_yaml() {
@@ -50,10 +85,7 @@ mod tests {
         let output =
             OutputWriter::from_args(Some(temp_file.path().to_path_buf()), false, None).unwrap();
 
-        let config = CommonConfig::new()
-            .with_formatter(FormatterConfig::new().with_indent(2).with_width(80));
-        let cmd = FormatCommand::new(config);
-        assert!(cmd.execute(&input, &output).is_ok());
+        assert!(make_cmd(false).execute(&input, &output).is_ok());
 
         let formatted = std::fs::read_to_string(temp_file.path()).unwrap();
         assert!(formatted.contains("name:"));
@@ -66,13 +98,8 @@ mod tests {
             content: "invalid: [".to_string(),
             origin: InputOrigin::Stdin,
         };
-
         let output = OutputWriter::stdout();
-
-        let config = CommonConfig::new()
-            .with_formatter(FormatterConfig::new().with_indent(2).with_width(80));
-        let cmd = FormatCommand::new(config);
-        assert!(cmd.execute(&input, &output).is_err());
+        assert!(make_cmd(false).execute(&input, &output).is_err());
     }
 
     #[test]
@@ -88,10 +115,52 @@ mod tests {
 
         let config = CommonConfig::new()
             .with_formatter(FormatterConfig::new().with_indent(4).with_width(80));
-        let cmd = FormatCommand::new(config);
-        assert!(cmd.execute(&input, &output).is_ok());
+        assert!(
+            FormatCommand::new(config, false)
+                .execute(&input, &output)
+                .is_ok()
+        );
 
         let formatted = std::fs::read_to_string(temp_file.path()).unwrap();
         assert!(formatted.contains("parent:"));
+    }
+
+    #[test]
+    fn test_format_with_comments_no_flag_errors() {
+        let input = InputSource {
+            content: "# top-level comment\nname: test".to_string(),
+            origin: InputOrigin::Stdin,
+        };
+        let output = OutputWriter::stdout();
+        let err = make_cmd(false).execute(&input, &output).unwrap_err();
+        assert!(err.to_string().contains("--strip-comments"));
+    }
+
+    #[test]
+    fn test_format_with_comments_strip_flag_succeeds() {
+        let input = InputSource {
+            content: "# top-level comment\nname: test".to_string(),
+            origin: InputOrigin::Stdin,
+        };
+        let temp_file = NamedTempFile::new().unwrap();
+        let output =
+            OutputWriter::from_args(Some(temp_file.path().to_path_buf()), false, None).unwrap();
+        assert!(make_cmd(true).execute(&input, &output).is_ok());
+    }
+
+    #[test]
+    fn test_yaml_has_comments_detects_inline() {
+        assert!(yaml_has_comments("key: value # inline"));
+    }
+
+    #[test]
+    fn test_yaml_has_comments_ignores_hash_in_string() {
+        assert!(!yaml_has_comments("key: \"value # not a comment\""));
+        assert!(!yaml_has_comments("key: 'value # not a comment'"));
+    }
+
+    #[test]
+    fn test_yaml_has_comments_no_comment() {
+        assert!(!yaml_has_comments("key: value\nother: 123"));
     }
 }

--- a/crates/fast-yaml-cli/src/main.rs
+++ b/crates/fast-yaml-cli/src/main.rs
@@ -89,6 +89,7 @@ fn run() -> Result<ExitCode> {
             exclude,
             no_recursive,
             dry_run,
+            strip_comments,
         }) => {
             // Determine if this is batch mode
             let is_batch = is_batch_mode(&paths, stdin_files, &include, &exclude, jobs);
@@ -144,7 +145,7 @@ fn run() -> Result<ExitCode> {
                         .with_indent(indent)
                         .with_width(width),
                 );
-                let cmd = commands::format::FormatCommand::new(format_config);
+                let cmd = commands::format::FormatCommand::new(format_config, strip_comments);
                 cmd.execute(&input, &output)?;
                 ExitCode::Success
             } else {
@@ -158,7 +159,7 @@ fn run() -> Result<ExitCode> {
                         .with_indent(indent)
                         .with_width(width),
                 );
-                let cmd = commands::format::FormatCommand::new(format_config);
+                let cmd = commands::format::FormatCommand::new(format_config, strip_comments);
                 cmd.execute(&input, &output)?;
                 ExitCode::Success
             }
@@ -274,7 +275,7 @@ fn run() -> Result<ExitCode> {
             let format_config = common_config
                 .clone()
                 .with_formatter(config::FormatterConfig::new().with_indent(2).with_width(80));
-            let cmd = commands::format::FormatCommand::new(format_config);
+            let cmd = commands::format::FormatCommand::new(format_config, false);
             cmd.execute(&input, &output)?;
             ExitCode::Success
         }


### PR DESCRIPTION
## Summary

- `fy format` now detects YAML comments in the input before formatting
- If comments are found and `--strip-comments` is not passed, exits with code 1 and prints a warning to stderr
- New `--strip-comments` flag: when passed, formatting proceeds silently and comments are stripped
- Updated `fy format --help` text and README to document the new behavior

Fixes #199

## Test plan

- [ ] `fy format file.yaml` with comments → exits 1, stderr warning
- [ ] `fy format --strip-comments file.yaml` with comments → exits 0, comments stripped
- [ ] `fy format file.yaml` without comments → exits 0, unchanged behavior
- [ ] `cargo nextest run -p fast-yaml-cli` → 139/139 passed