### PR TITLE
fix(core): preserve hex/octal integer overflow as String instead of coercing to float

### DIFF
--- a/crates/fast-yaml-core/src/parser.rs
+++ b/crates/fast-yaml-core/src/parser.rs
@@ -150,6 +150,17 @@ fn is_integer_literal(s: &str) -> bool {
     !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())
 }
 
+/// Returns `true` if `s` is a hex (`0x`/`0X`) or octal (`0o`/`0O`) integer literal.
+fn is_hex_octal_integer_literal(s: &str) -> bool {
+    let s = s.strip_prefix(['+', '-']).unwrap_or(s);
+    let tail = s.strip_prefix("0x")
+        .or_else(|| s.strip_prefix("0X"))
+        .or_else(|| s.strip_prefix("0o"))
+        .or_else(|| s.strip_prefix("0O"));
+    // Must have at least one digit after the prefix to be a valid literal.
+    matches!(tail, Some(t) if !t.is_empty())
+}
+
 /// Attempt to coerce a float string to `i64` via truncation toward zero (`PyYAML` convention).
 ///
 /// Returns `None` for non-finite values (.nan, .inf) and values outside the `i64` range.
@@ -217,7 +228,7 @@ fn coerce_representation(s: &str, style: ScalarStyle, tag: Option<&Tag>) -> Valu
         "false" | "False" | "FALSE" => ScalarOwned::Boolean(false),
         other => parse_core_schema_int(other).map_or_else(
             || {
-                if is_integer_literal(other) {
+                if is_integer_literal(other) || is_hex_octal_integer_literal(other) {
                     ScalarOwned::String(other.into())
                 } else {
                     parse_core_schema_float(other).map_or_else(


### PR DESCRIPTION
## Summary

Fixes #230. When a hex (`0x`) or octal (`0o`) integer literal exceeds `i64::MAX`, `parse_core_schema_int` returns `None` and the value previously fell through to `parse_core_schema_float`, silently losing precision (same class of bug as #229, which fixed decimal overflow).

## Change

- Add `is_hex_octal_integer_literal()` helper to detect hex/octal literal form
- In `coerce_representation()`, treat hex/octal overflow the same as decimal overflow: coerce to `ScalarOwned::String` instead of falling through to float parsing

```yaml
# Before: FloatingPoint (lossy)
# After: String (preserved raw literal)
x: 0x8000000000000000   # 2^63, overflows i64
y: 0o1000000000000000000000  # octal overflow
```

The fix follows the same pattern already used for decimal integer overflow (`is_integer_literal` check at the same call site).