### PR TITLE
release: v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Non-specific tag `!` on a scalar (e.g. `x: ! 99`) now forces the failsafe schema and returns a string (`"99"`) instead of applying implicit type resolution; matches YAML 1.2 §6.8.1 / §10.3.2 and PyYAML behaviour ([#238](https://github.com/bug-ops/fast-yaml/issues/238))
 - Hex (`0x...`) and octal (`0o...`) integer literals that overflow `i64` are now preserved as strings instead of being silently coerced to float; `is_integer_literal` and the `!!int` tag path now recognise hex/octal prefixes ([#230](https://github.com/bug-ops/fast-yaml/issues/230))
 - Large integers exceeding `i64` range are now correctly preserved as Python `int` instead of being coerced to `float` ([#229](https://github.com/bug-ops/fast-yaml/issues/229), closes [#227](https://github.com/bug-ops/fast-yaml/issues/227))
+- Linter: resolve `sort_by` and `collapsible_match` Clippy warnings in `linter.rs` and `quoted_strings.rs`
+
+### Dependencies
+
+- Bump `pyo3` ([#218](https://github.com/bug-ops/fast-yaml/pull/218))
+- Bump `rand` 0.9.2 → 0.9.4 ([#224](https://github.com/bug-ops/fast-yaml/pull/224))
+- Bump `pytest` ([#223](https://github.com/bug-ops/fast-yaml/pull/223))
+- Bump `vite` ([#219](https://github.com/bug-ops/fast-yaml/pull/219))
+- Bump `actions/github-script` 8 → 9 ([#225](https://github.com/bug-ops/fast-yaml/pull/225))
+- Bump `softprops/action-gh-release` 2 → 3 ([#220](https://github.com/bug-ops/fast-yaml/pull/220))
+- Bump `dependabot/fetch-metadata` 2 → 3 ([#221](https://github.com/bug-ops/fast-yaml/pull/221))
+- Bump `lewagon/wait-on-check-action` 1.6.0 → 1.7.0 ([#222](https://github.com/bug-ops/fast-yaml/pull/222), [#226](https://github.com/bug-ops/fast-yaml/pull/226))
 
 ## [0.6.1] - 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-04-26
+
 ### Added
 
 - yaml-test-suite integration in Python CI: parametrized ~400 test cases against `fast_yaml.safe_load()` / `safe_load_all()`, pinned to `data-2022-01-17` tag ([#228](https://github.com/bug-ops/fast-yaml/issues/228))
@@ -648,7 +650,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python package documentation
 - Node.js package documentation
 
-[Unreleased]: https://github.com/bug-ops/fast-yaml/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/bug-ops/fast-yaml/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/bug-ops/fast-yaml/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/bug-ops/fast-yaml/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/bug-ops/fast-yaml/compare/v0.5.3...v0.6.0
 [0.5.3]: https://github.com/bug-ops/fast-yaml/compare/v0.5.2...v0.5.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "criterion",
  "fast-yaml-core",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bumpalo",
  "criterion",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-linter"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "fast-yaml-core",
  "indoc",
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-nodejs"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "fast-yaml-core",
  "fast-yaml-linter",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-parallel"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "criterion",
  "fast-yaml-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -26,9 +26,9 @@ repository = "https://github.com/bug-ops/fast-yaml"
 
 [workspace.dependencies]
 # Internal crates
-fast-yaml-core = { path = "crates/fast-yaml-core", version = "0.6.1" }
-fast-yaml-linter = { path = "crates/fast-yaml-linter", version = "0.6.1" }
-fast-yaml-parallel = { path = "crates/fast-yaml-parallel", version = "0.6.1" }
+fast-yaml-core = { path = "crates/fast-yaml-core", version = "0.6.2" }
+fast-yaml-linter = { path = "crates/fast-yaml-linter", version = "0.6.2" }
+fast-yaml-parallel = { path = "crates/fast-yaml-parallel", version = "0.6.2" }
 
 # External dependencies - production
 anyhow = { version = "1" }

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ bash benches/comparison/scripts/run_nodejs_benchmark.sh  # Node.js API
 bash benches/comparison/scripts/run_batch_benchmark.sh   # CLI batch mode
 ```
 
-**Test environment:** macOS 14, Apple M3 Pro (12 cores), fast-yaml 0.6.1, PyYAML 6.0.3, js-yaml 4.1.1, Node.js 25.2.1, yamlfmt 0.21.0
+**Test environment:** macOS 14, Apple M3 Pro (12 cores), fast-yaml 0.6.2, PyYAML 6.0.3, js-yaml 4.1.1, Node.js 25.2.1, yamlfmt 0.21.0
 
 </details>
 

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastyaml-rs",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Fast YAML 1.2.2 parser, linter, and parallel processor for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastyaml-rs"
-version = "0.6.1"
+version = "0.6.2"
 description = "A fast YAML parser and linter for Python, powered by Rust"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bump version from 0.6.1 to 0.6.2
- Update CHANGELOG.md with release notes for v0.6.2
- Refresh README version reference

## Checklist

- [ ] Version updated in all manifests
- [ ] CHANGELOG.md has release section with date
- [ ] README reflects new version
- [ ] All CI checks pass
- [ ] Ready for tagging after merge