### PR TITLE
fix(ci): make crates.io publish step idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,33 +108,16 @@ jobs:
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
 
-      # Publish crates in dependency order
-      # Each crate waits for crates.io index update before proceeding
-      - name: Publish fast-yaml-core
-        run: cargo publish -p fast-yaml-core --no-verify
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-
-      - name: Wait for crates.io index update
-        run: sleep 30
-
-      - name: Publish fast-yaml-linter
-        run: cargo publish -p fast-yaml-linter --no-verify
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-
-      - name: Publish fast-yaml-parallel
-        run: cargo publish -p fast-yaml-parallel --no-verify
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-
-      - name: Wait for crates.io index update
-        run: sleep 30
-
-      - name: Publish fast-yaml-cli
-        run: cargo publish -p fast-yaml-cli --no-verify
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+      # Publish crates in dependency order (core → linter/parallel → cli).
+      # ignore-unpublished-changes: true makes this step idempotent — if the
+      # version was already published (e.g. tag re-pushed after a partial run),
+      # the action skips that crate instead of failing the whole job.
+      - name: Publish crates to crates.io
+        uses: katyo/publish-crates@v2
+        with:
+          registry-token: ${{ steps.auth.outputs.token }}
+          ignore-unpublished-changes: true
+          publish-delay: 30000
 
   # Build Python wheels for Linux (using manylinux containers)
   build-python-linux:


### PR DESCRIPTION
## Summary

- Replaces four individual `cargo publish` calls (with manual `sleep 30` waits) with a single `katyo/publish-crates@v2` step
- Sets `ignore-unpublished-changes: true` so the action skips crates that are already at the current version on crates.io, rather than failing
- Sets `publish-delay: 30000` (30 s) so the action waits for the crates.io index to propagate between crates — matching the previous manual sleeps
- The action respects workspace dependency order automatically

## Why

When a release tag is re-pushed after a partial run (e.g. the first two crates published but the job timed out), the old approach would fail immediately on the already-published crates. The new approach is idempotent: it skips what is already there and continues publishing the remaining crates.

## Test plan

- [ ] Trigger a release tag on a test repo to confirm the action publishes all four crates in dependency order
- [ ] Verify that re-running the job with no version change (simulating a retry) produces a successful no-op rather than a failure