### PR TITLE
fix(ci): replace --use-napi-cross with native cross-compilation setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,55 +382,30 @@ jobs:
           # Linux GNU
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            build: |
-              cd nodejs
-              pnpm run build -- --target x86_64-unknown-linux-gnu
-              strip *.node
 
-          # Linux musl (uses zig for cross-compilation)
+          # Linux musl
           - host: ubuntu-latest
             target: x86_64-unknown-linux-musl
-            build: |
-              cd nodejs
-              pnpm run build -- --target x86_64-unknown-linux-musl --use-napi-cross
-              strip *.node
 
-          # Linux ARM64 (uses zig for cross-compilation)
+          # Linux ARM64
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            build: |
-              cd nodejs
-              pnpm run build -- --target aarch64-unknown-linux-gnu --use-napi-cross
 
           # macOS x86_64
           - host: macos-latest
             target: x86_64-apple-darwin
-            build: |
-              cd nodejs
-              pnpm run build -- --target x86_64-apple-darwin
-              strip -x *.node
 
           # macOS ARM64 (Apple Silicon)
           - host: macos-latest
             target: aarch64-apple-darwin
-            build: |
-              cd nodejs
-              pnpm run build -- --target aarch64-apple-darwin
-              strip -x *.node
 
           # Windows x64
           - host: windows-latest
             target: x86_64-pc-windows-msvc
-            build: |
-              cd nodejs
-              pnpm run build -- --target x86_64-pc-windows-msvc
 
           # Windows ARM64
           - host: windows-latest
             target: aarch64-pc-windows-msvc
-            build: |
-              cd nodejs
-              pnpm run build -- --target aarch64-pc-windows-msvc
 
     steps:
       - uses: actions/checkout@v6
@@ -457,23 +432,33 @@ jobs:
         with:
           shared-key: "nodejs-${{ matrix.settings.target }}"
 
+      - name: Setup cross-compilation (Linux ARM64)
+        if: matrix.settings.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+
+      - name: Setup musl (Linux x64 musl)
+        if: matrix.settings.target == 'x86_64-unknown-linux-musl'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
       - name: Install dependencies
         run: cd nodejs && pnpm install --no-frozen-lockfile
 
-      # Build with Docker for cross-compilation targets
-      - name: Build in Docker
-        if: matrix.settings.docker
-        uses: addnab/docker-run-action@v3
-        with:
-          image: ${{ matrix.settings.docker }}
-          options: -v ${{ github.workspace }}:/build -w /build
-          run: ${{ matrix.settings.build }}
-
-      # Build natively
-      - name: Build native
-        if: "!matrix.settings.docker"
-        run: ${{ matrix.settings.build }}
+      - name: Build
+        run: cd nodejs && pnpm run build --target ${{ matrix.settings.target }}
         shell: bash
+
+      - name: Strip binary (Linux GNU)
+        if: matrix.settings.target == 'x86_64-unknown-linux-gnu' || matrix.settings.target == 'aarch64-unknown-linux-gnu'
+        run: strip nodejs/*.node || true
+
+      - name: Strip binary (macOS)
+        if: startsWith(matrix.settings.host, 'macos')
+        run: strip -x nodejs/*.node || true
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- Remove `--use-napi-cross` flag which is not supported in napi-rs CLI v3 (was causing `unexpected argument` error for `aarch64-unknown-linux-gnu` and `x86_64-unknown-linux-musl` targets)
- Replace with native cross-compilation setup matching the project reference pattern:
  - Linux ARM64: install `gcc-aarch64-linux-gnu` + set `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER`
  - Linux musl: install `musl-tools`
- Simplify matrix by removing inline `build` scripts — all targets now use a single `pnpm run build --target` step
- Remove dead `Build in Docker` step (no matrix entry had a `docker` field)

## Checklist

- [ ] `aarch64-unknown-linux-gnu` build passes
- [ ] `x86_64-unknown-linux-musl` build passes
- [ ] All other targets unaffected