### PR TITLE
release: v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-05-26
+
+### Fixed
+
+- CI: Python Cargo cache key now includes the full patch version (e.g. `3.14.5`) so any patch update to the Python interpreter invalidates the cached build artifacts and prevents linker errors on Windows (`LNK1181: cannot open input file 'python314.lib'`)
+
+### Dependencies
+
+- Bump `rayon` 1.11.0 → 1.12.0 ([#248](https://github.com/bug-ops/fast-yaml/pull/248))
+- Bump `clap` 4.6.0 → 4.6.1 ([#248](https://github.com/bug-ops/fast-yaml/pull/248))
+- Bump `napi` 3.8.4 → 3.9.0, `napi-derive` 3.5.3 → 3.5.6, `napi-build` 2.3.1 → 2.3.2 ([#248](https://github.com/bug-ops/fast-yaml/pull/248), [#249](https://github.com/bug-ops/fast-yaml/pull/249), [#250](https://github.com/bug-ops/fast-yaml/pull/250))
+- Bump `assert_cmd` 2.2.0 → 2.2.2 ([#248](https://github.com/bug-ops/fast-yaml/pull/248), [#250](https://github.com/bug-ops/fast-yaml/pull/250))
+- Bump `bumpalo` 3.20.2 → 3.20.3, `serde_json` 1.0.149 → 1.0.150 ([#251](https://github.com/bug-ops/fast-yaml/pull/251))
+
 ## [0.6.2] - 2026-04-26
 
 ### Added
@@ -662,7 +676,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python package documentation
 - Node.js package documentation
 
-[Unreleased]: https://github.com/bug-ops/fast-yaml/compare/v0.6.2...HEAD
+[Unreleased]: https://github.com/bug-ops/fast-yaml/compare/v0.6.3...HEAD
+[0.6.3]: https://github.com/bug-ops/fast-yaml/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/bug-ops/fast-yaml/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/bug-ops/fast-yaml/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/bug-ops/fast-yaml/compare/v0.5.3...v0.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "criterion",
  "fast-yaml-core",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-cli"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bumpalo",
  "criterion",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-linter"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "fast-yaml-core",
  "indoc",
@@ -445,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-nodejs"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "fast-yaml-core",
  "fast-yaml-linter",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-parallel"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "criterion",
  "fast-yaml-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -26,9 +26,9 @@ repository = "https://github.com/bug-ops/fast-yaml"
 
 [workspace.dependencies]
 # Internal crates
-fast-yaml-core = { path = "crates/fast-yaml-core", version = "0.6.2" }
-fast-yaml-linter = { path = "crates/fast-yaml-linter", version = "0.6.2" }
-fast-yaml-parallel = { path = "crates/fast-yaml-parallel", version = "0.6.2" }
+fast-yaml-core = { path = "crates/fast-yaml-core", version = "0.6.3" }
+fast-yaml-linter = { path = "crates/fast-yaml-linter", version = "0.6.3" }
+fast-yaml-parallel = { path = "crates/fast-yaml-parallel", version = "0.6.3" }
 
 # External dependencies - production
 anyhow = { version = "1" }

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ bash benches/comparison/scripts/run_nodejs_benchmark.sh  # Node.js API
 bash benches/comparison/scripts/run_batch_benchmark.sh   # CLI batch mode
 ```
 
-**Test environment:** macOS 14, Apple M3 Pro (12 cores), fast-yaml 0.6.2, PyYAML 6.0.3, js-yaml 4.1.1, Node.js 25.2.1, yamlfmt 0.21.0
+**Test environment:** macOS 14, Apple M3 Pro (12 cores), fast-yaml 0.6.3, PyYAML 6.0.3, js-yaml 4.1.1, Node.js 25.2.1, yamlfmt 0.21.0
 
 </details>
 

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastyaml-rs",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Fast YAML 1.2.2 parser, linter, and parallel processor for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastyaml-rs"
-version = "0.6.2"
+version = "0.6.3"
 description = "A fast YAML parser and linter for Python, powered by Rust"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bump version from 0.6.2 to 0.6.3
- Update CHANGELOG.md with release section for 0.6.3
- Update `python/pyproject.toml` and `nodejs/package.json` to 0.6.3
- Refresh README benchmark test environment version

## Changes since v0.6.2

### Fixed

- CI: Python Cargo cache key now includes full Python patch version to prevent `LNK1181` linker errors on Windows when the runner updates its Python patch release

### Dependencies

- `rayon` 1.11.0 → 1.12.0
- `clap` 4.6.0 → 4.6.1
- `napi` 3.8.4 → 3.9.0, `napi-derive` 3.5.3 → 3.5.6, `napi-build` 2.3.1 → 2.3.2
- `assert_cmd` 2.2.0 → 2.2.2
- `bumpalo` 3.20.2 → 3.20.3, `serde_json` 1.0.149 → 1.0.150

## Checklist

- [x] Version updated in all manifests (Cargo.toml, pyproject.toml, package.json)
- [x] Cargo.lock regenerated
- [x] CHANGELOG.md has release section with date
- [x] README reflects new version
- [x] All CI checks pass locally (951 tests)
- [ ] Ready for tagging after merge