### PR TITLE
chore(deps): bump saphyr and saphyr-parser to 0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 
+- Bump `saphyr` 0.0.9 → 0.0.11 and `saphyr-parser` 0.0.9 → 0.0.11 (combined, since both crates are released in lockstep from the same upstream repository; bumping either alone leaves two mismatched `saphyr_parser` versions in the dependency graph and fails to compile) ([#270](https://github.com/bug-ops/fast-yaml/pull/270), [#271](https://github.com/bug-ops/fast-yaml/pull/271))
 - Bump `saphyr` 0.0.6 → 0.0.9 and `saphyr-parser` 0.0.6 → 0.0.9 (combined, since both crates are released in lockstep from the same upstream repository) ([#266](https://github.com/bug-ops/fast-yaml/pull/266), [#267](https://github.com/bug-ops/fast-yaml/pull/267))
 
 ## [0.6.4] - 2026-06-13

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "saphyr"
-version = "0.0.9"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5bcc48916766e53689486df76c80ccf62a38f20d20b816056ff6ab84197cbd"
+checksum = "8acd6cfc4803660d26a3fb5bd8f5e47bc0eea5229f4d32f7cb4ee21a733e6961"
 dependencies = [
  "encoding_rs",
  "hashlink",
@@ -1312,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "saphyr-parser"
-version = "0.0.9"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbeae0f40b92f2afe16422744aabb145187167184cc18bf4d01da5acdc665f09"
+checksum = "ebfd783fcf1b3f6bafd557be0e1427ec54f826f513c3cdd749f9844484df2a13"
 dependencies = [
  "arraydeque",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ num_cpus = { version = "1.17" }
 ordered-float = { version = "5" }
 pyo3 = { version = "0.29" }
 rayon = { version = "1.12" }
-saphyr = { version = "0.0.9" }
-saphyr-parser = { version = "0.0.9" }
+saphyr = { version = "0.0.11" }
+saphyr-parser = { version = "0.0.11" }
 serde = { version = "1.0" }
 serde_json = { version = "1.0" }
 serde_norway = { version = "0.9" }


### PR DESCRIPTION
## Summary

- Bumps `saphyr` and `saphyr-parser` together from 0.0.9 to 0.0.11.
- Supersedes #270 and #271, which each bump only one of the two crates. Since `saphyr` re-exports `saphyr-parser` types, bumping either alone leaves two mismatched `saphyr_parser` versions in the dependency graph, breaking the build with `E0277`/`E0308` in `fast-yaml-core::parser`/`emitter` (`ScalarStyle`, `Tag`, `ScanError`, `EventReceiver` type mismatches).
- No source changes were needed beyond the version bump; existing `From<saphyr::ScanError>` and coercion code compiles unchanged against 0.0.11.

## Test plan

- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude fast-yaml --exclude fast-yaml-nodejs --lib --bins` (919 passed)
- [x] `RUSTFLAGS="-D warnings" RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --workspace --exclude fast-yaml --exclude fast-yaml-nodejs`