### PR TITLE
fix(nodejs): tighten pnpm overrides to clear audit high vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `vite` 8.0.10 → 8.0.16 in Node.js bindings to fix GHSA-7qr8-wg58-9r72 (`server.fs.deny` bypass on Windows) and GHSA-4vq8-g365-vhgc (NTLMv2 hash disclosure via UNC path handling on Windows)
 - Bump `js-yaml` (transitive, via `@napi-rs/cli`) to >=4.3.0 via pnpm override to fix GHSA-52cp-r559-cp3m (YAML merge-key chains can force quadratic CPU consumption)
+- Tighten the `js-yaml` pnpm override from an open-ended `>=4.3.0` to `^4.3.0`, which was resolving to the vulnerable `js-yaml` 5.2.1 and reintroducing GHSA-pm4m-ph32-ghv5 (exponential parsing time in flow collections)
+- Add a `postcss` pnpm override (`>=8.5.18`) in Node.js bindings to fix GHSA-r28c-9q8g-f849 (path traversal via `sourceMappingURL` auto-loading), pulled in transitively through `vitest > vite > postcss`
 
 ### Dependencies
 

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -68,7 +68,8 @@
   "pnpm": {
     "overrides": {
       "vite": ">=8.0.16",
-      "js-yaml": ">=4.3.0"
+      "js-yaml": "^4.3.0",
+      "postcss": ">=8.5.18"
     }
   }
 }

--- a/nodejs/pnpm-lock.yaml
+++ b/nodejs/pnpm-lock.yaml
@@ -6,7 +6,8 @@ settings:
 
 overrides:
   vite: '>=8.0.16'
-  js-yaml: '>=4.3.0'
+  js-yaml: ^4.3.0
+  postcss: '>=8.5.18'
 
 importers:
 
@@ -957,8 +958,8 @@ packages:
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   json-with-bigint@3.5.8:
@@ -1055,8 +1056,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.14:
-    resolution: {integrity: sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1074,8 +1075,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   rolldown@1.0.3:
@@ -1455,7 +1456,7 @@ snapshots:
       colorette: 2.0.20
       emnapi: 1.11.1
       es-toolkit: 1.48.1
-      js-yaml: 5.2.1
+      js-yaml: 4.3.0
       obug: 2.1.3
       semver: 7.8.5
       typanion: 3.14.0
@@ -1995,7 +1996,7 @@ snapshots:
 
   js-tokens@10.0.0: {}
 
-  js-yaml@5.2.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -2068,7 +2069,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.14: {}
+  nanoid@3.3.16: {}
 
   obug@2.1.3: {}
 
@@ -2078,9 +2079,9 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.15:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.14
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2149,7 +2150,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.23
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Tightens the `js-yaml` pnpm override in `nodejs/package.json` from open-ended `>=4.3.0` to `^4.3.0`. The open-ended range let pnpm resolve `js-yaml` to 5.2.1, reintroducing GHSA-pm4m-ph32-ghv5 (exponential parsing time in flow collections) despite the override having originally been added to fix a different js-yaml advisory.
- Adds a `postcss` pnpm override (`>=8.5.18`) to fix GHSA-r28c-9q8g-f849 (path traversal via `sourceMappingURL` auto-loading), pulled in transitively via `vitest > vite > postcss`.
- This is what was failing `NodeJS Quality Checks` / `pnpm audit --audit-level=high` on `main` and on unrelated PRs (e.g. #277), independent of their own changes.

## Test plan
- [x] `pnpm audit --audit-level=high` in `nodejs/` reports no known vulnerabilities
- [x] `pnpm run typecheck`, `format:check`, `lint` pass
- [x] `pnpm run build:debug` and `pnpm run test` pass (337 passed, 1 skipped)
- [x] `cargo +nightly fmt --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --exclude fast-yaml-python --exclude fast-yaml-node --lib --bins` (951 passed)
- [x] `cargo doc --no-deps --workspace` with rustdoc broken-link gate