### PR TITLE
release: v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.5] - 2026-07-27
+
 ### Added
 
 - Release pipeline now builds and attaches prebuilt `fy` CLI binaries to every GitHub release (Linux x86_64/aarch64 glibc, Linux x86_64 musl, macOS x86_64/aarch64, Windows x86_64), each packaged with a `.sha256` checksum. Linux aarch64 musl (e.g. Alpine on ARM64) is not yet published — build from source with `cargo install fast-yaml-cli`
 - `scripts/install.sh`: POSIX-sh installer that detects the host OS/arch/libc (including musl via `/lib/ld-musl-*` or `ldd --version`), downloads the matching prebuilt `fy` binary, verifies its checksum, and installs it to `~/.local/bin` (or `$FASTYAML_INSTALL_DIR`)
-- `skills/fast-yaml-cli/SKILL.md`, an Agent Skill documenting installation and usage of the `fy` CLI for AI coding agents
+- `skills/fast-yaml-cli/SKILL.md`, an Agent Skill documenting installation and usage of the `fy` CLI for AI coding agents ([#276](https://github.com/bug-ops/fast-yaml/pull/276))
 
 ### Security
 
-- Bump `vite` 8.0.10 → 8.0.16 in Node.js bindings to fix GHSA-7qr8-wg58-9r72 (`server.fs.deny` bypass on Windows) and GHSA-4vq8-g365-vhgc (NTLMv2 hash disclosure via UNC path handling on Windows)
-- Bump `js-yaml` (transitive, via `@napi-rs/cli`) to >=4.3.0 via pnpm override to fix GHSA-52cp-r559-cp3m (YAML merge-key chains can force quadratic CPU consumption)
-- Tighten the `js-yaml` pnpm override from an open-ended `>=4.3.0` to `^4.3.0`, which was resolving to the vulnerable `js-yaml` 5.2.1 and reintroducing GHSA-pm4m-ph32-ghv5 (exponential parsing time in flow collections)
-- Add a `postcss` pnpm override (`>=8.5.18`) in Node.js bindings to fix GHSA-r28c-9q8g-f849 (path traversal via `sourceMappingURL` auto-loading), pulled in transitively through `vitest > vite > postcss`
+- Bump `crossbeam-epoch` (transitive, via `ignore` and `rayon-core`) 0.9.18 → 0.9.20 to fix RUSTSEC-2026-0204 (invalid pointer dereference in the `fmt::Pointer` impl) ([#265](https://github.com/bug-ops/fast-yaml/pull/265))
+- Bump `js-yaml` (transitive, via `@napi-rs/cli`) to >=4.3.0 via pnpm override to fix GHSA-52cp-r559-cp3m (YAML merge-key chains can force quadratic CPU consumption) ([#276](https://github.com/bug-ops/fast-yaml/pull/276))
+- Tighten the `js-yaml` pnpm override from an open-ended `>=4.3.0` to `^4.3.0`, which was resolving to the vulnerable `js-yaml` 5.2.1 and reintroducing GHSA-pm4m-ph32-ghv5 (exponential parsing time in flow collections) ([#280](https://github.com/bug-ops/fast-yaml/pull/280))
+- Add a `postcss` pnpm override (`>=8.5.18`) in Node.js bindings to fix GHSA-r28c-9q8g-f849 (path traversal via `sourceMappingURL` auto-loading), pulled in transitively through `vitest > vite > postcss` ([#280](https://github.com/bug-ops/fast-yaml/pull/280))
 
 ### Dependencies
 
-- Bump `saphyr` 0.0.9 → 0.0.11 and `saphyr-parser` 0.0.9 → 0.0.11 (combined, since both crates are released in lockstep from the same upstream repository; bumping either alone leaves two mismatched `saphyr_parser` versions in the dependency graph and fails to compile) ([#270](https://github.com/bug-ops/fast-yaml/pull/270), [#271](https://github.com/bug-ops/fast-yaml/pull/271))
-- Bump `saphyr` 0.0.6 → 0.0.9 and `saphyr-parser` 0.0.6 → 0.0.9 (combined, since both crates are released in lockstep from the same upstream repository) ([#266](https://github.com/bug-ops/fast-yaml/pull/266), [#267](https://github.com/bug-ops/fast-yaml/pull/267))
+- Bump `saphyr` 0.0.9 → 0.0.11 and `saphyr-parser` 0.0.9 → 0.0.11 (combined, since both crates are released in lockstep from the same upstream repository; bumping either alone leaves two mismatched `saphyr_parser` versions in the dependency graph and fails to compile) ([#272](https://github.com/bug-ops/fast-yaml/pull/272))
+- Bump `saphyr` 0.0.6 → 0.0.9 and `saphyr-parser` 0.0.6 → 0.0.9 (combined, since both crates are released in lockstep from the same upstream repository) ([#268](https://github.com/bug-ops/fast-yaml/pull/268))
+- Bump `napi` 3.9.4 → 3.11.0, `napi-derive` 3.5.7 → 3.6.0 ([#265](https://github.com/bug-ops/fast-yaml/pull/265), [#269](https://github.com/bug-ops/fast-yaml/pull/269), [#275](https://github.com/bug-ops/fast-yaml/pull/275), [#279](https://github.com/bug-ops/fast-yaml/pull/279))
+- Bump `ignore` 0.4.26 → 0.4.31 ([#265](https://github.com/bug-ops/fast-yaml/pull/265), [#269](https://github.com/bug-ops/fast-yaml/pull/269), [#275](https://github.com/bug-ops/fast-yaml/pull/275), [#279](https://github.com/bug-ops/fast-yaml/pull/279))
+- Bump `clap` 4.6.1 → 4.6.4 ([#275](https://github.com/bug-ops/fast-yaml/pull/275), [#279](https://github.com/bug-ops/fast-yaml/pull/279))
+- Bump `memchr` 2.8.2 → 2.8.3 ([#269](https://github.com/bug-ops/fast-yaml/pull/269))
+- Bump `anyhow` 1.0.103 → 1.0.104, `globset` 0.4.18 → 0.4.19, `serde` 1.0.228 → 1.0.229, `serde_json` 1.0.150 → 1.0.151, `thiserror` 2.0.18 → 2.0.19 ([#275](https://github.com/bug-ops/fast-yaml/pull/275))
+- Bump `glob` 0.3.3 → 0.3.4 ([#279](https://github.com/bug-ops/fast-yaml/pull/279))
+- Bump `actions/setup-node` 6 → 7 ([#273](https://github.com/bug-ops/fast-yaml/pull/273))
+- Bump `actions/setup-python` 6 → 7 ([#274](https://github.com/bug-ops/fast-yaml/pull/274))
+- Bump `actions/labeler` 6 → 7 ([#278](https://github.com/bug-ops/fast-yaml/pull/278))
+- Bump `lewagon/wait-on-check-action` 1.8.0 → 1.9.0 ([#264](https://github.com/bug-ops/fast-yaml/pull/264), [#277](https://github.com/bug-ops/fast-yaml/pull/277))
 
 ## [0.6.4] - 2026-06-13
+
+### Security
+
+- Bump `vite` 8.0.10 → 8.0.16 in Node.js bindings to fix GHSA-7qr8-wg58-9r72 (`server.fs.deny` bypass on Windows) and GHSA-4vq8-g365-vhgc (NTLMv2 hash disclosure via UNC path handling on Windows) ([#260](https://github.com/bug-ops/fast-yaml/pull/260))
 
 ### Dependencies
 
@@ -703,7 +719,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python package documentation
 - Node.js package documentation
 
-[Unreleased]: https://github.com/bug-ops/fast-yaml/compare/v0.6.4...HEAD
+[Unreleased]: https://github.com/bug-ops/fast-yaml/compare/v0.6.5...HEAD
+[0.6.5]: https://github.com/bug-ops/fast-yaml/compare/v0.6.4...v0.6.5
 [0.6.4]: https://github.com/bug-ops/fast-yaml/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/bug-ops/fast-yaml/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/bug-ops/fast-yaml/compare/v0.6.1...v0.6.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,19 +126,19 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -155,9 +155,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -228,7 +228,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -329,9 +329,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "ctor"
-version = "1.0.7"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
+checksum = "e9bb72bb94fdc1bd619f4c18cc91ecf6302aeb333d31b3c6ec0bb841cd920209"
 
 [[package]]
 name = "difflib"
@@ -341,9 +341,9 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encoding_rs"
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "criterion",
  "fast-yaml-core",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-cli"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-core"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "bumpalo",
  "criterion",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-linter"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "fast-yaml-core",
  "indoc",
@@ -445,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-nodejs"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "fast-yaml-core",
  "fast-yaml-linter",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "fast-yaml-parallel"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "criterion",
  "fast-yaml-core",
@@ -475,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -502,21 +502,15 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -529,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -539,15 +533,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -556,38 +550,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -614,15 +608,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -657,20 +649,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -679,7 +662,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
- "hashbrown 0.17.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -693,12 +676,6 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ignore"
@@ -723,9 +700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
- "serde",
- "serde_core",
+ "hashbrown",
 ]
 
 [[package]]
@@ -771,9 +746,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -781,16 +756,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -810,9 +779,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
@@ -864,7 +833,7 @@ dependencies = [
  "napi-derive-backend",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -877,7 +846,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semver",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -993,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "ppv-lite86"
@@ -1037,20 +1006,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1116,7 +1075,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1128,7 +1087,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1139,9 +1098,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1160,9 +1119,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1218,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1230,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1247,9 +1206,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"
@@ -1266,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -1353,7 +1312,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1402,9 +1361,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1413,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1435,7 +1394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1474,7 +1433,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1504,12 +1463,6 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml-norway"
@@ -1548,23 +1501,14 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1575,9 +1519,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1585,65 +1529,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1697,120 +1607,32 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -26,9 +26,9 @@ repository = "https://github.com/bug-ops/fast-yaml"
 
 [workspace.dependencies]
 # Internal crates
-fast-yaml-core = { path = "crates/fast-yaml-core", version = "0.6.4" }
-fast-yaml-linter = { path = "crates/fast-yaml-linter", version = "0.6.4" }
-fast-yaml-parallel = { path = "crates/fast-yaml-parallel", version = "0.6.4" }
+fast-yaml-core = { path = "crates/fast-yaml-core", version = "0.6.5" }
+fast-yaml-linter = { path = "crates/fast-yaml-linter", version = "0.6.5" }
+fast-yaml-parallel = { path = "crates/fast-yaml-parallel", version = "0.6.5" }
 
 # External dependencies - production
 anyhow = { version = "1" }
@@ -41,9 +41,9 @@ ignore = { version = "0.4" }
 is-terminal = { version = "0.4" }
 memchr = { version = "2.8" }
 memmap2 = { version = "0.9" }
-napi = { version = "3.9" }
+napi = { version = "3.11" }
 napi-build = { version = "2.3" }
-napi-derive = { version = "3.5" }
+napi-derive = { version = "3.6" }
 num_cpus = { version = "1.17" }
 ordered-float = { version = "5" }
 pyo3 = { version = "0.29" }
@@ -60,7 +60,7 @@ assert_cmd = { version = "2.2" }
 criterion = { version = "0.8" }
 indoc = { version = "2.0" }
 predicates = { version = "3.1" }
-proptest = { version = "1.10" }
+proptest = { version = "1.11" }
 tempfile = { version = "3.27" }
 
 [workspace.lints.rust]

--- a/README.md
+++ b/README.md
@@ -24,12 +24,18 @@ pip install fastyaml-rs
 # Node.js
 npm install fastyaml-rs
 
-# CLI
+# CLI (prebuilt binary — no Rust toolchain required)
+curl -fsSL https://raw.githubusercontent.com/bug-ops/fast-yaml/main/scripts/install.sh | sh
+
+# CLI (from source via cargo)
 cargo install fast-yaml-cli
 ```
 
 > [!WARNING]
-> Requires Rust 1.88+, Python 3.10+ or Node.js 20+
+> Requires Rust 1.88+, Python 3.10+ or Node.js 20+ (only for building from source — the prebuilt CLI binary has no runtime dependencies)
+
+> [!NOTE]
+> `scripts/install.sh` detects the host OS/arch/libc (including musl) and downloads the matching prebuilt `fy` binary with checksum verification from the [GitHub releases](https://github.com/bug-ops/fast-yaml/releases). Linux aarch64 musl (e.g. Alpine on ARM64) has no prebuilt binary yet — use `cargo install fast-yaml-cli` instead. Pin a version with `FASTYAML_VERSION=v0.6.5`, or change the install directory with `FASTYAML_INSTALL_DIR`.
 
 <details>
 <summary><b>Build from source</b></summary>

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastyaml-rs",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Fast YAML 1.2.2 parser, linter, and parallel processor for Node.js",
   "main": "index.js",
   "types": "index.d.ts",
@@ -58,12 +58,12 @@
     "version": "napi version"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.0",
-    "@napi-rs/cli": "^3.7.1",
-    "@types/node": "^25.9.3",
-    "@vitest/coverage-v8": "^4.1.8",
+    "@biomejs/biome": "^2.5.5",
+    "@napi-rs/cli": "^3.7.4",
+    "@types/node": "^25.9.5",
+    "@vitest/coverage-v8": "^4.1.10",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.10"
   },
   "pnpm": {
     "overrides": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastyaml-rs"
-version = "0.6.3"
+version = "0.6.5"
 description = "A fast YAML parser and linter for Python, powered by Rust"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/skills/fast-yaml-cli/SKILL.md
+++ b/skills/fast-yaml-cli/SKILL.md
@@ -9,7 +9,7 @@ compatibility: |-
   or install script: `curl -fsSL https://raw.githubusercontent.com/bug-ops/fast-yaml/main/scripts/install.sh | sh` (macOS, Linux only).
 metadata:
   author: bug-ops
-  version: "0.6.4"
+  version: "0.6.5"
 ---
 
 ## Installation
@@ -32,7 +32,7 @@ Downloads prebuilt binary from latest GitHub Release, verifies checksum with sha
 
 **Pinning to a specific version:**
 ```bash
-FASTYAML_VERSION=v0.6.4 curl -fsSL https://raw.githubusercontent.com/bug-ops/fast-yaml/main/scripts/install.sh | sh
+FASTYAML_VERSION=v0.6.5 curl -fsSL https://raw.githubusercontent.com/bug-ops/fast-yaml/main/scripts/install.sh | sh
 ```
 
 **Custom install directory:**
@@ -46,23 +46,23 @@ FASTYAML_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com
 
 1. Go to https://github.com/bug-ops/fast-yaml/releases
 2. Download the prebuilt `.tar.gz` archive for your OS/arch:
-   - macOS x86_64: `fy-v0.6.4-x86_64-apple-darwin.tar.gz`
-   - macOS ARM64: `fy-v0.6.4-aarch64-apple-darwin.tar.gz`
-   - Linux x86_64 (glibc): `fy-v0.6.4-x86_64-unknown-linux-gnu.tar.gz`
-   - Linux x86_64 (musl/Alpine): `fy-v0.6.4-x86_64-unknown-linux-musl.tar.gz`
-   - Linux ARM64: `fy-v0.6.4-aarch64-unknown-linux-gnu.tar.gz`
+   - macOS x86_64: `fy-v0.6.5-x86_64-apple-darwin.tar.gz`
+   - macOS ARM64: `fy-v0.6.5-aarch64-apple-darwin.tar.gz`
+   - Linux x86_64 (glibc): `fy-v0.6.5-x86_64-unknown-linux-gnu.tar.gz`
+   - Linux x86_64 (musl/Alpine): `fy-v0.6.5-x86_64-unknown-linux-musl.tar.gz`
+   - Linux ARM64: `fy-v0.6.5-aarch64-unknown-linux-gnu.tar.gz`
 3. Download the corresponding `.sha256` checksum file
-4. Verify: `sha256sum -c fy-v0.6.4-*.tar.gz.sha256` (or `shasum -a 256`)
-5. Extract: `tar -xzf fy-v0.6.4-*.tar.gz`
-6. Move binary to PATH: `mv fy-v0.6.4-*/fy /usr/local/bin/`
+4. Verify: `sha256sum -c fy-v0.6.5-*.tar.gz.sha256` (or `shasum -a 256`)
+5. Extract: `tar -xzf fy-v0.6.5-*.tar.gz`
+6. Move binary to PATH: `mv fy-v0.6.5-*/fy /usr/local/bin/`
 
 #### Windows
 
 1. Go to https://github.com/bug-ops/fast-yaml/releases
-2. Download: `fy-v0.6.4-x86_64-pc-windows-msvc.zip`
+2. Download: `fy-v0.6.5-x86_64-pc-windows-msvc.zip`
 3. Download the corresponding `.sha256` checksum file
 4. Verify the archive (before extracting) — see "Checksum verification" in [Platform Notes → Windows](#windows) section below
-5. Extract: `Expand-Archive -Path fy-v0.6.4-x86_64-pc-windows-msvc.zip -DestinationPath .`
+5. Extract: `Expand-Archive -Path fy-v0.6.5-x86_64-pc-windows-msvc.zip -DestinationPath .`
 6. Move `fy.exe` to your chosen `%PATH%` directory
 
 ### From Source
@@ -403,9 +403,9 @@ When downloaded, the binary is named `fy.exe`. Add its directory to `%PATH%` via
 
 Checksum verification on Windows (required before extracting):
 ```powershell
-Get-FileHash -Path fy-v0.6.4-x86_64-pc-windows-msvc.zip -Algorithm SHA256
+Get-FileHash -Path fy-v0.6.5-x86_64-pc-windows-msvc.zip -Algorithm SHA256
 ```
-Compare the output hash against the `.sha256` file downloaded from the release. Then extract with `Expand-Archive -Path fy-v0.6.4-x86_64-pc-windows-msvc.zip -DestinationPath .` and move the `fy.exe` binary to your chosen `%PATH%` directory.
+Compare the output hash against the `.sha256` file downloaded from the release. Then extract with `Expand-Archive -Path fy-v0.6.5-x86_64-pc-windows-msvc.zip -DestinationPath .` and move the `fy.exe` binary to your chosen `%PATH%` directory.
 
 ### PATH Setup Across Shells
 


### PR DESCRIPTION
## Summary

- Bump version 0.6.4 -> 0.6.5 across all manifests (Cargo workspace, `nodejs/package.json`, `python/pyproject.toml`)
- Verified all 13 commits since v0.6.4 and reconciled CHANGELOG.md accordingly: corrected mismatched PR references for the saphyr bumps, added previously undocumented entries (RUSTSEC-2026-0204 fix via crossbeam-epoch, CI action bumps for setup-node/setup-python/labeler/wait-on-check-action)
- Retroactively documented a security fix (vite GHSA-7qr8-wg58-9r72 / GHSA-4vq8-g365-vhgc) that had shipped in v0.6.4 but was missing from that release's changelog section
- Documented the new prebuilt CLI binary install method (`scripts/install.sh`) in README.md installation section
- Synced version references in `skills/fast-yaml-cli/SKILL.md`

## Checklist

- [x] Version updated in all manifests
- [x] CHANGELOG.md has release section with date
- [x] README reflects new install method
- [x] All local checks pass (fmt, clippy, 951 tests, release build, rustdoc gate)
- [ ] Ready for tagging after merge